### PR TITLE
Docker and Air-Verse improvements

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "tmp/main"
+  cmd = "templ generate && go build -o tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go", "_templ.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "templ", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = true
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  enabled = true
+  app_port = 8080
+  proxy_port = 7331
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,34 @@
 # Use a base image with Go pre-installed
 FROM docker.io/golang:1.23.5 as my-dev-environment
 
-# Set working directory
-# WORKDIR /app
+# enable when using lib
+# ENV CGO_ENABLED=1
 
 # Install system dependencies and task runner
-RUN apt-get update && apt-get install -y \
-    curl \
-    sudo \
-    git \
-    sqlite3 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get install -y curl sudo git sqlite3
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
 
 # Install task runner
 # RUN sh -c "$(curl --silent --location https://taskfile.dev/install.sh)" -- -d
 
+# Copy over and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Install project deeps
+RUN go install github.com/a-h/templ/cmd/templ@latest
+RUN go install github.com/air-verse/air@latest
+RUN go install github.com/go-task/task/v3/cmd/task@latest
+
 # Create a user and group named devuser
-RUN groupadd -g 1000 devuser && \
-    useradd -m -u 1000 -g devuser -s /bin/bash devuser
+RUN groupadd -g 1000 devuser
+RUN useradd -m -u 1000 -g devuser -s /bin/bash devuser
 
 # Configure passwordless sudo for the devuser user
-RUN echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser && \
-    chmod 0440 /etc/sudoers.d/devuser
+RUN echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser
+RUN chmod 0440 /etc/sudoers.d/devuser
 
 # Switch to the 'devuser' user
 USER devuser
@@ -29,15 +36,5 @@ USER devuser
 # Set up the working directory for the user
 WORKDIR /home/devuser/app
 
-# Copy go.mod and go.sum and download dependencies
-# COPY go.mod go.sum ./
-# RUN go mod download
-
-# Install templ and air globally
-RUN go install github.com/a-h/templ/cmd/templ@latest && \
-    go install github.com/go-task/task/v3/cmd/task@latest && \
-    go install github.com/air-verse/air@latest
-
 # Expose ports used by the application
 EXPOSE 8080 7331
-

--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ https://www.youtube.com/watch?v=ALGBuFLzDSA
 https://www.youtube.com/watch?v=NhTPVXP8n7w&t=219s
 
 ## Docker setup
+You have two options when it comes to running this poject, you can either use the bash or powershell script or docker compose cli.
 
-To build the docker image run the following command:
-
-```bash
+### Script method
+First build an image with the following command, then execute either [run-docker.sh](run-docker.sh) or [run-docker.ps1](run-docker.ps1) script depeding on your OS.
+```console
  docker build --rm -t my-dev-environment .
 ```
 
-To run the docker image use the run-docker bash or powershell script.
-
-## Go dependencies 
-```bash
-go install github.com/air-verse/air@latest
-go install github.com/a-h/templ/cmd/templ@latest
+### Compose method
+To build the docker image and mount a container, run the following command:
+```console
+ docker compose up
 ```
+
 ## Links
 
 Se the [northstar](https://github.com/zangster300/northstar) README for installation instructions.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
   live:templ:
     cmds:
       - go run github.com/a-h/templ/cmd/templ@v0.3.833 generate --watch --proxybind="0.0.0.0" --proxy="http://localhost:8080" --open-browser=false -v
-      
+
   live:server:
     cmds:
       - |
@@ -56,6 +56,12 @@ tasks:
       - live:reload
       - live:server
 
+  # Start development server
+  dev:
+    cmds:
+      - air -c .air.toml
+
+  # Run current build
   run:
     cmds:
       - ./bin/main

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  webserver:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: regncon-image
+    # tty required by air when using compose
+    tty: true
+    ports:
+      - 7331:7331
+      - 8080:8080
+    volumes:
+      - type: bind
+        source: ./
+        target: /home/devuser/app
+        read_only: false
+    command: task dev


### PR DESCRIPTION
## Docker  & compose
I've gone over and adjusted some of our configs in the `Dockerfile` and added a `compose.yaml` file for this project. You can create an image and mount a container with just the following command.
```console
docker compose up
```
Project structure should remain the same thus letting existing scrips still work alongside compose for those who want to use existing methods.

## Taskfile & Air
I've also made a new entry into our taskfile that utilizes a local copy of air along with its config file `.air.toml`, this config specifies:
- Detection method from watch to pooling due to windows/unix cross-incompatibility (fs.watch/inotify)
- Specified proxy here instead of in Templ cmd. Result is the same :>

## Closing notes
There are some lines we can remove in our Docker, Taskfile & Air config files, but for now I've just focused on adding functionality without doing any breaking changes