### PR TITLE
Air proxy fix

### DIFF
--- a/.air-dev.toml
+++ b/.air-dev.toml
@@ -43,7 +43,7 @@ tmp_dir = "tmp"
   clean_on_exit = false
 
 [proxy]
-  enabled = false
+  enabled = true
   app_port = 8080
   proxy_port = 7331
 

--- a/.air-dev.toml
+++ b/.air-dev.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "tmp/main"
-  cmd = "templ generate && go build -buildvcs=false -o tmp/main ."
+  cmd = "templ generate && go build -o tmp/main ."
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []
@@ -43,7 +43,7 @@ tmp_dir = "tmp"
   clean_on_exit = false
 
 [proxy]
-  enabled = true
+  enabled = false
   app_port = 8080
   proxy_port = 7331
 

--- a/.air-dev.toml
+++ b/.air-dev.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "tmp/main"
-  cmd = "templ generate && go build -o tmp/main ."
+  cmd = "templ generate && go build -buildvcs=false -o tmp/main ."
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,29 @@
 {
-  "gopls": {
-    "build.buildFlags": ["-tags=dev"]
-  },
-  "go.useLanguageServer": true,
-  "[templ]": {
-    "editor.defaultFormatter": "a-h.templ"
-  },
-  "cSpell.words": [
-    "Atoi",
-    "Dadbod",
-    "dbod",
-    "DBUI",
-    "ifmissing",
-    "joerdav",
-    "keymap",
-    "kristijanhusak",
-    "omitempty",
-    "println",
-    "strconv",
-    "ticketholder",
-    "ticketholders",
-    "tpope"
-  ]
+    "gopls": {
+        "build.buildFlags": ["-tags=dev"]
+    },
+    "go.useLanguageServer": true,
+    "[templ]": {
+        "editor.defaultFormatter": "a-h.templ"
+    },
+    "cSpell.words": [
+        "Atoi",
+        "Dadbod",
+        "dbod",
+        "DBUI",
+        "devuser",
+        "GOMODCACHE",
+        "ifmissing",
+        "joerdav",
+        "keymap",
+        "kristijanhusak",
+        "NOPASSWD",
+        "omitempty",
+        "passwordless",
+        "println",
+        "strconv",
+        "ticketholder",
+        "ticketholders",
+        "tpope"
+    ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a base image with Go pre-installed
-FROM docker.io/golang:1.23.5 as my-dev-environment
+FROM golang:1.24 AS my-dev-environment
 
 # enable when using lib
 # ENV CGO_ENABLED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,52 @@
-# Use a base image with Go pre-installed
 FROM golang:1.24 AS my-dev-environment
 
-# enable when using lib
-# ENV CGO_ENABLED=1
+# Enable CGO (required for some C-based Go libraries)
+ENV CGO_ENABLED=1
 
-# Install system dependencies and task runner
-RUN apt-get update
-RUN apt-get install -y curl sudo git sqlite3
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+# Install necessary system dependencies
+RUN apt-get update && \
+    apt-get install -y curl sudo git sqlite3 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install task runner
-# RUN sh -c "$(curl --silent --location https://taskfile.dev/install.sh)" -- -d
+# Create a user group named 'devuser' with group ID 1000
+RUN groupadd -g 1000 devuser
 
-# Copy over and download dependencies
-COPY go.mod go.sum ./
+# Create a user named 'devuser' with user ID 1000, assign it to the 'devuser' group, and set its shell to bash
+RUN useradd -m -u 1000 -g devuser -s /bin/bash devuser
+
+# Configure passwordless sudo access for the 'devuser' user
+RUN echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser && \
+    chmod 0440 /etc/sudoers.d/devuser
+
+# Set up the Go module cache directory for the 'devuser' user
+ENV GOMODCACHE=/home/devuser/go/pkg/mod
+
+# Set the working directory for the application
+WORKDIR /home/devuser/app
+
+# Create the Go module cache directory and set ownership to 'devuser'
+RUN mkdir -p /home/devuser/go/pkg/mod && \
+    chown -R devuser:devuser /home/devuser/go
+
+# Switch to the 'devuser' user for subsequent commands
+USER devuser
+
+# Copy go.mod and go.sum with proper ownership
+COPY --chown=devuser:devuser go.mod go.sum ./
+
+# Download Go module dependencies
 RUN go mod download
 
-# Install project deeps
+# Update to latest version of templ in mod file (might not be necessary because it dont work this way)
+RUN cd /home/devuser/app && go get -u github.com/a-h/templ
+
+# Install project-specific tools
 RUN go install github.com/a-h/templ/cmd/templ@latest
 RUN go install github.com/air-verse/air@latest
 RUN go install github.com/go-task/task/v3/cmd/task@latest
 
-# Create a user and group named devuser
-RUN groupadd -g 1000 devuser
-RUN useradd -m -u 1000 -g devuser -s /bin/bash devuser
-
-# Configure passwordless sudo for the devuser user
-RUN echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser
-RUN chmod 0440 /etc/sudoers.d/devuser
-
-# Switch to the 'devuser' user
-USER devuser
-
-# Set up the working directory for the user
-WORKDIR /home/devuser/app
-
-# Expose ports used by the application
+# Expose ports used by the application:
+# - 8080: Application's main HTTP server
+# - 7331: Air live reload server
 EXPOSE 8080 7331

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Choose your preferred method to run the project:
 
 ### Docker Setup (Recommended for Windows)
    ```bash
-   docker compose up
+   docker compose up --build
    ```
 
 > [!NOTE]
@@ -93,12 +93,12 @@ Common issues and solutions:
 
 #### 1. Required Tools
 
-| Tool | Description | Installation Command |
-|------|-------------|---------------------|
-| [Go](https://go.dev/doc/install) | Programming language | Follow installation guide
-| [Templ](https://templ.guide) | Template engine | `go install github.com/a-h/templ/cmd/templ@latest`
-| [Air](https://github.com/cosmtrek/air) | Live reload tool | `go install github.com/air-verse/air@latest`
-| [Task](https://taskfile.dev/installation) | Task runner | Follow installation guide
+| Tool                                      | Description          | Installation Command                               |
+| ----------------------------------------- | -------------------- | -------------------------------------------------- |
+| [Go](https://go.dev/doc/install)          | Programming language | Follow installation guide                          |
+| [Templ](https://templ.guide)              | Template engine      | `go install github.com/a-h/templ/cmd/templ@latest` |
+| [Air](https://github.com/cosmtrek/air)    | Live reload tool     | `go install github.com/air-verse/air@latest`       |
+| [Task](https://taskfile.dev/installation) | Task runner          | Follow installation guide                          |
 
 #### 2. Shell Configuration
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,4 +14,4 @@ services:
         source: ./
         target: /home/devuser/app
         read_only: false
-    command: task dev
+    command: air -c .air-dev.toml


### PR DESCRIPTION
We've recently had some issues making live reloads work when using Air-Verse's proxy binding. After some testing I've found that the issue might lie with our version of golang used when creating the docker image.
After updating to the most recent release of `1.24` from `1.23.5` live reloads now works, even without specifying proxy in Air-Verse.

This PR proposes the following changes
- Updating golang to current release `1.24`
- Renaming Air-Verse config file from `.air.toml` to `.air-dev.toml` soo that it doesn't default bind on init
- Disabling proxy bind in Air-Verse as it still works (somehow)
- Changing default compose cmd to skip taskfile as it is not used during development. Now targets air with dev config