### PR TITLE
modified cssVariable component keybind to not conflict with user inputs

### DIFF
--- a/components/modals/css_variable_config.templ
+++ b/components/modals/css_variable_config.templ
@@ -338,7 +338,7 @@ templ CssVariableConfigComponent() {
 
                 function init(){
                     document.addEventListener("keydown", function(event) {
-                        if (event.shiftKey && event.key.toLowerCase() === "s") {
+                        if (event.shiftKey && event.altKey && event.key.toLowerCase() === "d") {
                             toggleCssVariableConfig()
                         }
                     })


### PR DESCRIPTION
Rebinding cssVariable() tool to use `shift` `alt` `d` instead of just `shift` `s` to avoid conflicts with normal user interactions