### PR TITLE
Creating backup service application

### DIFF
--- a/backup-service/config/config.go
+++ b/backup-service/config/config.go
@@ -4,29 +4,18 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/Regncon/conorganizer/backup-service/models"
 	"github.com/joho/godotenv"
 )
 
-// Config Application configs and secrets
-type Config struct {
-	AWS_ENDPOINT_URL_S3   string
-	AWS_ACCESS_KEY_ID     string
-	AWS_SECRET_ACCESS_KEY string
-	AWS_REGION            string
-	BUCKET_NAME           string
-	DB_PREFIX             string
-	DISCORD_WEBHOOK_URL   string
-	DISCORD_SECRET_KEY    string
-}
-
 // Load Loads the required system environment variables
-func Load(logger *slog.Logger) Config {
+func Load(logger *slog.Logger) models.Config {
 	err := godotenv.Load()
 	if err != nil {
 		logger.Error("Error loading .env file")
 	}
 
-	return Config{
+	return models.Config{
 		AWS_ENDPOINT_URL_S3:   os.Getenv("AWS_ENDPOINT_URL_S3"),
 		AWS_ACCESS_KEY_ID:     os.Getenv("AWS_ACCESS_KEY_ID"),
 		AWS_SECRET_ACCESS_KEY: os.Getenv("AWS_SECRET_ACCESS_KEY"),

--- a/backup-service/config/config.go
+++ b/backup-service/config/config.go
@@ -23,6 +23,5 @@ func Load(logger *slog.Logger) models.Config {
 		BUCKET_NAME:           os.Getenv("BUCKET_NAME"),
 		DB_PREFIX:             os.Getenv("DB_PREFIX"),
 		DISCORD_WEBHOOK_URL:   os.Getenv("DISCORD_WEBHOOK_URL"),
-		DISCORD_SECRET_KEY:    os.Getenv("DISCORD_SECRET_KEY"),
 	}
 }

--- a/backup-service/database/initialize.sql
+++ b/backup-service/database/initialize.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS backup_logs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     backup_type TEXT NOT NULL CHECK (backup_type IN ('hourly', 'daily', 'weekly', 'yearly', 'manually')),
     status TEXT NOT NULL CHECK (status IN ('pending', 'error', 'success')),
-    message TEXT NOT NULL,
+    message TEXT NOT NULL DEFAULT '',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/backup-service/docker-compose.yml
+++ b/backup-service/docker-compose.yml
@@ -4,6 +4,8 @@ services:
             context: .
             dockerfile: Dockerfile
         container_name: backup-dev
+        volumes:
+            - .:/data
         env_file:
             - .env
         restart: unless-stopped

--- a/backup-service/dockerfile
+++ b/backup-service/dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24.5 AS builder
 ENV CGO_ENABLED=1
 
 # Install required libs
-RUN apt-get update -y && apt-get install -y ca-certificates sqlite3
+RUN apt-get update -y && apt-get install -y ca-certificates sqlite3 tzdata
 
 # Set workdir for building application
 WORKDIR /usr/src/codebase
@@ -23,7 +23,7 @@ FROM debian:bookworm AS server
 RUN groupadd -r regncon && useradd -r -g regncon -d /srv/regncon -s /usr/sbin/nologin regncon
 
 # Install required libs
-RUN apt-get update -y && apt-get install -y ca-certificates sqlite3
+RUN apt-get update -y && apt-get install -y ca-certificates sqlite3 tzdata
 
 # Copy compiled binary from previous step
 COPY --from=builder /usr/local/bin/backup-service /home/regncon/backup-service

--- a/backup-service/main.go
+++ b/backup-service/main.go
@@ -12,6 +12,9 @@ import (
 )
 
 func main() {
+	// Set timezone
+	os.Setenv("TZ", "Europe/Oslo")
+
 	// Set up logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 

--- a/backup-service/main.go
+++ b/backup-service/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	// Define backup service
-	backupService := services.NewBackupService(cfg, s3Client, logger)
+	backupService := services.NewBackupService(cfg, db, s3Client, logger)
 
 	// Start scheduler
 	err = services.StartScheduler(backupService, logger)

--- a/backup-service/models/backup.go
+++ b/backup-service/models/backup.go
@@ -1,11 +1,33 @@
 package models
 
+import (
+	"database/sql"
+	"log/slog"
+)
+
 type BackupInterval string
+type BackupStage string
 
 const (
-	Hourly   BackupInterval = "hourly"
-	Daily    BackupInterval = "daily"
-	Weekly   BackupInterval = "weekly"
-	Yearly   BackupInterval = "yearly"
-	Manually BackupInterval = "manually"
+	Hourly        BackupInterval = "hourly"
+	Daily         BackupInterval = "daily"
+	Weekly        BackupInterval = "weekly"
+	Yearly        BackupInterval = "yearly"
+	Manually      BackupInterval = "manually"
+	Initializing  BackupStage    = "starting"
+	Downloading   BackupStage    = "downloading"
+	Decompressing BackupStage    = "decompressing"
+	Moving        BackupStage    = "moving"
+	Finalizing    BackupStage    = "finalizing"
 )
+
+type BackupOutcome struct {
+	DB         *sql.DB
+	LogID      int64
+	Status     BackupLogStatus
+	Error      string
+	Stage      BackupStage
+	Interval   BackupInterval
+	Logger     *slog.Logger
+	WebhookURL string
+}

--- a/backup-service/models/config.go
+++ b/backup-service/models/config.go
@@ -8,5 +8,4 @@ type Config struct {
 	BUCKET_NAME           string
 	DB_PREFIX             string
 	DISCORD_WEBHOOK_URL   string
-	DISCORD_SECRET_KEY    string
 }

--- a/backup-service/models/config.go
+++ b/backup-service/models/config.go
@@ -1,0 +1,12 @@
+package models
+
+type Config struct {
+	AWS_ENDPOINT_URL_S3   string
+	AWS_ACCESS_KEY_ID     string
+	AWS_SECRET_ACCESS_KEY string
+	AWS_REGION            string
+	BUCKET_NAME           string
+	DB_PREFIX             string
+	DISCORD_WEBHOOK_URL   string
+	DISCORD_SECRET_KEY    string
+}

--- a/backup-service/models/discord.go
+++ b/backup-service/models/discord.go
@@ -1,0 +1,20 @@
+package models
+
+type DiscordEmbedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline"`
+}
+
+type DiscordEmbed struct {
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Color       int                 `json:"color,omitempty"`
+	Timestamp   string              `json:"timestamp,omitempty"`
+	Fields      []DiscordEmbedField `json:"fields,omitempty"`
+}
+
+type DiscordWebhookPayload struct {
+	Content string         `json:"content"`
+	Embeds  []DiscordEmbed `json:"embeds"`
+}

--- a/backup-service/models/logger.go
+++ b/backup-service/models/logger.go
@@ -11,7 +11,7 @@ const (
 type BackupLogInput struct {
 	ID      int64
 	Status  BackupLogStatus
-	Message error
+	Message string
 }
 
 type BackupLogMessage struct {

--- a/backup-service/models/logger.go
+++ b/backup-service/models/logger.go
@@ -1,0 +1,22 @@
+package models
+
+type BackupLogStatus string
+
+const (
+	Pending BackupLogStatus = "pending"
+	Success BackupLogStatus = "success"
+	Error   BackupLogStatus = "error"
+)
+
+type BackupLogInput struct {
+	ID      int64
+	Status  BackupLogStatus
+	Message error
+}
+
+type BackupLogMessage struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Intro       string `json:"intro"`
+	Description string `json:"description"`
+}

--- a/backup-service/services/discord.go
+++ b/backup-service/services/discord.go
@@ -5,24 +5,54 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Regncon/conorganizer/backup-service/models"
 )
 
-type DiscordWebhookPayload struct {
-	Content string `json:"content"`
-}
-
-func SendDiscordMessage(cfg models.Config, message string) error {
-	payload := DiscordWebhookPayload{Content: message}
-	webhookUrl := cfg.DISCORD_WEBHOOK_URL
+func SendDiscordMessage(outcome models.BackupOutcome) error {
+	payload := models.DiscordWebhookPayload{
+		Content: ":face_with_peeking_eye:",
+		Embeds: []models.DiscordEmbed{
+			{
+				Title: "Regncon backup-service error!",
+				Color: 16711680,
+				Fields: []models.DiscordEmbedField{
+					{
+						Name:   "Stage",
+						Value:  string(outcome.Stage),
+						Inline: true,
+					},
+					{
+						Name:   "Type",
+						Value:  string(outcome.Interval),
+						Inline: true,
+					},
+					{},
+					{
+						Name:   "When",
+						Value:  time.Now().Format("Mon, 02 Jan 15:04:05"),
+						Inline: true,
+					}, {
+						Name:   "Link",
+						Value:  "[Coming soon!](https://google.com)",
+						Inline: true,
+					},
+					{
+						Name:  "Error message",
+						Value: outcome.Error,
+					},
+				},
+			},
+		},
+	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal webhook payload: %w", err)
 	}
 
-	res, err := http.Post(webhookUrl, "application/json", bytes.NewBuffer(body))
+	res, err := http.Post(outcome.WebhookURL, "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("failed to send webhook: %w", err)
 	}

--- a/backup-service/services/discord.go
+++ b/backup-service/services/discord.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Regncon/conorganizer/backup-service/models"
+)
+
+type DiscordWebhookPayload struct {
+	Content string `json:"content"`
+}
+
+func SendDiscordMessage(cfg models.Config, message string) error {
+	payload := DiscordWebhookPayload{Content: message}
+	webhookUrl := cfg.DISCORD_WEBHOOK_URL
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	res, err := http.Post(webhookUrl, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to send webhook: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		return fmt.Errorf("webhook returned non-successful status: %s", res.Status)
+	}
+
+	return nil
+}

--- a/backup-service/services/logger.go
+++ b/backup-service/services/logger.go
@@ -20,15 +20,10 @@ func NewLogBackup(db *sql.DB, intervalType models.BackupInterval) (int64, error)
 }
 
 func UpdateLogBackup(db *sql.DB, input models.BackupLogInput) error {
-	msg := ""
-	if input.Message != nil {
-		msg = input.Message.Error()
-	}
-
 	_, err := db.Exec(`
         UPDATE backup_logs
         SET status = ?, message = ?
         WHERE id = ?
-    `, input.Status, msg, input.ID)
+    `, input.Status, input.Message, input.ID)
 	return err
 }

--- a/backup-service/services/logger.go
+++ b/backup-service/services/logger.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"database/sql"
+
+	"github.com/Regncon/conorganizer/backup-service/models"
+)
+
+func NewLogBackup(db *sql.DB, intervalType models.BackupInterval) (int64, error) {
+	res, err := db.Exec(`
+        INSERT INTO backup_logs (backup_type, status, message)
+        VALUES (?, 'pending', '')
+    `, intervalType)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return res.LastInsertId()
+}
+
+func UpdateLogBackup(db *sql.DB, input models.BackupLogInput) error {
+	msg := ""
+	if input.Message != nil {
+		msg = input.Message.Error()
+	}
+
+	_, err := db.Exec(`
+        UPDATE backup_logs
+        SET status = ?, message = ?
+        WHERE id = ?
+    `, input.Status, msg, input.ID)
+	return err
+}

--- a/backup-service/services/s3.go
+++ b/backup-service/services/s3.go
@@ -14,11 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/Regncon/conorganizer/backup-service/config"
+	"github.com/Regncon/conorganizer/backup-service/models"
 )
 
 // NewS3Client creates and configures an S3 client from the provided config.
-func NewS3Client(cfg config.Config, logger *slog.Logger) (*s3.Client, error) {
+func NewS3Client(cfg models.Config, logger *slog.Logger) (*s3.Client, error) {
 	logger.Info("Initializing Tigris S3 client", slog.Group("tigris",
 		slog.String("endpoint", cfg.AWS_ENDPOINT_URL_S3),
 		slog.String("region", cfg.AWS_REGION),


### PR DESCRIPTION
Backup-service er en søsterapplikasjon av conorganizer som er deployet på fly.io. Applikasjonen er ansvarlig for å kjøre backups av s3 storage til et mountet volume hos fly.io og gjør dette hver; time, dag, uke og år.

I tillegg til å kjøre backups av database kan denne applikasjonen loggføre hendelser og sende notifikasjoner til discord hvis det oppstår feil. Originalt planla jeg å lage en dashboard vi kan besøke for å se mer informasjon og statistikk, men dette har blitt utsatt pga jobben.

I denne PR ligger det også deployment scripts som kjører når filer i `/backup-service` endres på. Alle environment secrets er det samme som i conorganizer, så du kan kopiere den filen inn i mappen hvis du ønsker å kjøre prosjektet lokalt.