### PR TITLE
Tweak layouting på form-siden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 AS my-dev-environment
+FROM golang:1.25.1 AS my-dev-environment
 
 # Enable CGO (required for some C-based Go libraries)
 ENV CGO_ENABLED=1

--- a/components/formsubmission/about_event.templ
+++ b/components/formsubmission/about_event.templ
@@ -175,7 +175,7 @@ func UpdateDescription(eventRouter chi.Router, db *sql.DB, kv jetstream.KeyValue
 
 templ aboutEvent(eventId string, title string, intro string, eventType models.EventType, image string, system string, description string) {
 	<article class="form-card">
-		<h4>Om arrangementet</h4>
+		<h4 class="form-card-title">Om arrangementet</h4>
 		<section class="about-section">
 			<label class="label-small color-strong form-group title">
 				Tittel

--- a/components/formsubmission/contact_info.templ
+++ b/components/formsubmission/contact_info.templ
@@ -107,7 +107,7 @@ func UpdatePhone(eventRouter chi.Router, db *sql.DB, kv jetstream.KeyValue) {
 
 templ contactInfo(eventId string, name string, email string, phone string) {
 	<article class="form-card">
-		<h4>Om arrangøren</h4>
+		<h4 class="form-card-title">Om arrangøren</h4>
 		<section class="organizer-section">
 			<label class="label color-strong form-group">
 				Arrangør

--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -7,6 +7,11 @@ import (
 templ FormBody(event *models.Event) {
 	<style>
 		.formsubmission-wrapper {
+
+			h1.color-strong {
+				margin: var(--spacing-xlarge) 0;
+			}
+
 			> * + .form-card {
 				margin-block-start: 1rem;
 			}

--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -35,10 +35,6 @@ templ FormBody(event *models.Event) {
 			.form-card {
 				display: grid;
 
-				h4 {
-					margin: 0;
-				}
-
 				.organizer-section {
 					display: grid;
 					gap: 1.25rem;
@@ -109,9 +105,10 @@ templ FormBody(event *models.Event) {
 
 					.organizer-section {
 						display: flex;
-						justify-content: space-between;
+						gap: var(--spacing-medium);
 						.form-group {
 							gap: 0.5rem;
+							flex-grow: 1;
 						}
 					}
 
@@ -149,7 +146,6 @@ templ FormBody(event *models.Event) {
 					}
 
 					.details-section {
-						margin-block-start: 1rem;
 						grid-template-columns: minmax(7.5rem, 0.4fr) minmax(
 								12.5rem,
 								0.6fr

--- a/components/formsubmission/other_details.templ
+++ b/components/formsubmission/other_details.templ
@@ -206,7 +206,7 @@ func UpdateNotes(eventRouter chi.Router, db *sql.DB, kv jetstream.KeyValue) {
 
 templ otherDetails(eventId string, ageGroup models.AgeGroup, runtime models.Runtime, beginnerFriendly bool, canBeRunInEnglish bool, maxPlayers int, notes string) {
 	<article class="form-card">
-		<h4>Øvrige Detaljer</h4>
+		<h4 class="form-card-title">Øvrige Detaljer</h4>
 		<section class="details-section">
 			<label class="label-small color-strong form-group age-group">
 				Aldersgruppe

--- a/static/index.css
+++ b/static/index.css
@@ -174,17 +174,27 @@ body {
 }
 
 h1 {
+    margin: 0;
     color: var(--color-text-strong);
 }
 
 h3 {
+    margin: 0;
     font-weight: 700;
     font-size: var(--text-heading-3);
 }
 
 h4 {
+    margin: 0;
     font-weight: 400;
     font-size: var(--text-heading-4);
+}
+
+p {
+    margin: 0;
+}
+p + p {
+    margin-top: 1rem
 }
 
 hr {
@@ -281,7 +291,11 @@ input {
 .form-card {
     border-radius: var(--border-radius-medium);
     background-color: var(--bg-surface);
-    padding: 1rem;
+    padding: var(--spacing-medium);
+}
+
+.form-card-title {
+    margin-bottom: var(--spacing-xsmall);
 }
 
 .item-card {


### PR DESCRIPTION
Litt kjapp oppussing i layoutingen på Event Form siden. 

<img width="1816" height="1111" alt="image" src="https://github.com/user-attachments/assets/7cbebd1f-d3f2-4a3d-98bf-69512d82cb4e" />

- Normalisering av spacing for småtitlene i kortene 
- Litt opprydding i hvordan spacing blir lagt til 
- Unngå spacing før og etter et sett med Paragraph tags, bare ha spacing imellom de
- Fiks gapene mellom input-feltene i "Om arrangøren"