### PR TITLE
Update styles for width and heading on event approval page

### DIFF
--- a/pages/admin/approval/approval_page.templ
+++ b/pages/admin/approval/approval_page.templ
@@ -44,9 +44,11 @@ templ ApprovalPageContent(db *sql.DB, logger *slog.Logger) {
 		{Name: "Admin", Url: "/admin/"},
 		{Name: "Godkjenning av Arrangementer", Url: ""},
 	})
-	<div style="max-width: 910px; margin: auto;">
-		<p>Her kan du godkjenne arrangementer som er sendt inn av brukere.</p>
-		<h1>Arrangementer til Godkjenning</h1>
+	<div class="page-content-container">
+		<h1 class="page-heading has-helptext">Arrangementer til Godkjenning</h1>
+		<p class="page-heading-helptext">
+			Her kan du godkjenne arrangementer som er sendt inn av brukere.
+		</p>
 		for _, event := range events {
 			@eventBar(event)
 		}

--- a/static/index.css
+++ b/static/index.css
@@ -207,16 +207,28 @@ h1 {
 h1.page-heading {
     font-size: 32px;
     margin: var(--spacing-medium) 0;
+    &.has-helptext {
+        margin-bottom: var(--spacing-xsmall);
+    }
+}
+.page-heading-helptext {
+    margin-bottom: var(--spacing-medium);
 }
 @container main (width > 600px) {
     h1.page-heading {
         font-size: 40px;
         margin: var(--spacing-large) 0;
     }
+    .page-heading-helptext {
+        margin-bottom: var(--spacing-large);
+    }
 }
 @container main (width > 1000px) {
     h1.page-heading {
         margin: var(--spacing-xlarge) 0;
+    }
+    .page-heading-helptext {
+        margin-bottom: var(--spacing-xlarge);
     }
 }
 


### PR DESCRIPTION
<img width="1442" height="746" alt="image" src="https://github.com/user-attachments/assets/f63d711a-657f-4424-b942-27fa034e4280" />

Style updates for the admin event approval page that: 

- Applies the same page width as other pages now have. 
- Some room for there to be a subheading below a H1 on these pages, and the styles that makes it fall into place as a subheading.

Saw the text was present on the page, and thought it'd make a lot of sense for it to just look like this. 