### PR TITLE
190 | Update nav buttons in header

### DIFF
--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -1,0 +1,43 @@
+package header
+
+import (
+	"github.com/Regncon/conorganizer/service/requestctx"
+	"github.com/Regncon/conorganizer/components/icons"
+)
+
+templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
+  <style>
+    .main-menu-buttons {
+      width: 100%;
+      display: flex;
+      gap: var(--spacing-4x);
+
+      .main-menu-button {
+        color: var(--color-secondary);
+        text-decoration: none;
+      }
+    }
+  </style>
+  <section class="main-menu-buttons">
+    <a role="button" href="/" class="btn btn--ghost btn-with-icon">
+      @icons.Icon(icons.Home, icons.Size24)
+      <span>
+        Hjem
+      </span>
+    </a>
+    <a role="button" href="/" class="btn btn--ghost btn-with-icon">
+      @icons.Icon(icons.User, icons.Size24)
+      <span>
+        Min Side
+      </span>
+    </a>
+    if (UserInfo.IsAdmin) {
+      <a role="button" href="/" class="btn btn--ghost btn-with-icon">
+        @icons.Icon(icons.Shield, icons.Size24)
+        <span>
+          Admin
+        </span>
+      </a>
+    }
+  </section>
+}

--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -8,39 +8,61 @@ import (
 templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
 	<style>
     .main-menu-buttons {
-      container: main-menu-buttons;
-      container-type: normal;
-      width: 100%;
-      display: flex;
-      gap: var(--spacing-4x);
+      display: contents;
     }
 
     .main-menu-button {
+        display: flex;
         flex-direction: column;
         font-size: 12px;
-        height: 44px;
-        gap: 2px;
+        height: 48px;
+        padding: 0 var(--spacing-4x);
+        gap: var(--spacing-1x);
+        .menu-button-text {
+          white-space: nowrap;
+      }
+    }
+
+    @container main (width > 600px) {
+      .main-menu-buttons {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: var(--spacing-4x);
+      }
+      .main-menu-button {
+        flex-direction: row;
+        font-size: initial;
+        height: var(--btn-height);
+        padding: 0 var(--btn-padding-x);
+        gap: var(--spacing-2x);
+        .inline-icon {
+          width: 24px;
+          height: 24px;
+        }
+      }
     }
   </style>
 	<section class="main-menu-buttons">
 		<a role="button" href="/" class="main-menu-button btn btn--ghost btn-with-icon">
-			@icons.Icon(icons.Home, icons.Size24)
-			<span>
+			@icons.Icon(icons.Home, icons.Size20)
+			<span class="menu-button-text">
 				Hjem
 			</span>
 		</a>
     if (UserInfo.IsLoggedIn) {
       <a role="button" href="/my-events" class="main-menu-button btn btn--ghost btn-with-icon">
-        @icons.Icon(icons.User, icons.Size24)
-        <span>
+        @icons.Icon(icons.User, icons.Size20)
+        <span class="menu-button-text">
           Min Side
         </span>
       </a>
     }
 		if (UserInfo.IsLoggedIn && UserInfo.IsAdmin) {
 			<a role="button" href="/admin" class="main-menu-button btn btn--ghost btn-with-icon">
-				@icons.Icon(icons.Shield, icons.Size24)
-				<span>
+				@icons.Icon(icons.Shield, icons.Size20)
+				<span class="menu-button-text">
 					Admin
 				</span>
 			</a>

--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -20,13 +20,15 @@ templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
 				Hjem
 			</span>
 		</a>
-		<a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
-			@icons.Icon(icons.User, icons.Size24)
-			<span>
-				Min Side
-			</span>
-		</a>
-		if (UserInfo.IsAdmin) {
+    if (UserInfo.IsLoggedIn) {
+      <a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
+        @icons.Icon(icons.User, icons.Size24)
+        <span>
+          Min Side
+        </span>
+      </a>
+    }
+		if (UserInfo.IsLoggedIn && UserInfo.IsAdmin) {
 			<a role="button" href="/admin" class="btn btn--ghost btn-with-icon">
 				@icons.Icon(icons.Shield, icons.Size24)
 				<span>

--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -11,11 +11,6 @@ templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
       width: 100%;
       display: flex;
       gap: var(--spacing-4x);
-
-      .main-menu-button {
-        color: var(--color-secondary);
-        text-decoration: none;
-      }
     }
   </style>
   <section class="main-menu-buttons">
@@ -25,14 +20,14 @@ templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
         Hjem
       </span>
     </a>
-    <a role="button" href="/" class="btn btn--ghost btn-with-icon">
+    <a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
       @icons.Icon(icons.User, icons.Size24)
       <span>
         Min Side
       </span>
     </a>
     if (UserInfo.IsAdmin) {
-      <a role="button" href="/" class="btn btn--ghost btn-with-icon">
+      <a role="button" href="/admin" class="btn btn--ghost btn-with-icon">
         @icons.Icon(icons.Shield, icons.Size24)
         <span>
           Admin

--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -8,20 +8,29 @@ import (
 templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
 	<style>
     .main-menu-buttons {
+      container: main-menu-buttons;
+      container-type: normal;
       width: 100%;
       display: flex;
       gap: var(--spacing-4x);
     }
+
+    .main-menu-button {
+        flex-direction: column;
+        font-size: 12px;
+        height: 44px;
+        gap: 2px;
+    }
   </style>
 	<section class="main-menu-buttons">
-		<a role="button" href="/" class="btn btn--ghost btn-with-icon">
+		<a role="button" href="/" class="main-menu-button btn btn--ghost btn-with-icon">
 			@icons.Icon(icons.Home, icons.Size24)
 			<span>
 				Hjem
 			</span>
 		</a>
     if (UserInfo.IsLoggedIn) {
-      <a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
+      <a role="button" href="/my-events" class="main-menu-button btn btn--ghost btn-with-icon">
         @icons.Icon(icons.User, icons.Size24)
         <span>
           Min Side
@@ -29,7 +38,7 @@ templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
       </a>
     }
 		if (UserInfo.IsLoggedIn && UserInfo.IsAdmin) {
-			<a role="button" href="/admin" class="btn btn--ghost btn-with-icon">
+			<a role="button" href="/admin" class="main-menu-button btn btn--ghost btn-with-icon">
 				@icons.Icon(icons.Shield, icons.Size24)
 				<span>
 					Admin

--- a/components/header/main_menu_buttons.templ
+++ b/components/header/main_menu_buttons.templ
@@ -1,38 +1,38 @@
 package header
 
 import (
-	"github.com/Regncon/conorganizer/service/requestctx"
 	"github.com/Regncon/conorganizer/components/icons"
+	"github.com/Regncon/conorganizer/service/requestctx"
 )
 
 templ MainMenuButtons(UserInfo requestctx.UserRequestInfo) {
-  <style>
+	<style>
     .main-menu-buttons {
       width: 100%;
       display: flex;
       gap: var(--spacing-4x);
     }
   </style>
-  <section class="main-menu-buttons">
-    <a role="button" href="/" class="btn btn--ghost btn-with-icon">
-      @icons.Icon(icons.Home, icons.Size24)
-      <span>
-        Hjem
-      </span>
-    </a>
-    <a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
-      @icons.Icon(icons.User, icons.Size24)
-      <span>
-        Min Side
-      </span>
-    </a>
-    if (UserInfo.IsAdmin) {
-      <a role="button" href="/admin" class="btn btn--ghost btn-with-icon">
-        @icons.Icon(icons.Shield, icons.Size24)
-        <span>
-          Admin
-        </span>
-      </a>
-    }
-  </section>
+	<section class="main-menu-buttons">
+		<a role="button" href="/" class="btn btn--ghost btn-with-icon">
+			@icons.Icon(icons.Home, icons.Size24)
+			<span>
+				Hjem
+			</span>
+		</a>
+		<a role="button" href="/my-events" class="btn btn--ghost btn-with-icon">
+			@icons.Icon(icons.User, icons.Size24)
+			<span>
+				Min Side
+			</span>
+		</a>
+		if (UserInfo.IsAdmin) {
+			<a role="button" href="/admin" class="btn btn--ghost btn-with-icon">
+				@icons.Icon(icons.Shield, icons.Size24)
+				<span>
+					Admin
+				</span>
+			</a>
+		}
+	</section>
 }

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -152,6 +152,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			#main-menu-logo {
 				display: flex;
 				justify-content: flex-start;
+				width: 100%;
 				grid-area: logo;
 			}
 
@@ -162,12 +163,13 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			#main-menu-usermenu {
 				display: flex;
 				justify-content: flex-end;
+				width: 100%;
 				grid-area: usermenu;
 			}
 
 			.main-menu {
 				grid-template-areas: 'logo navbuttons usermenu';
-				grid-template-columns: 100px 1fr 100px;
+				grid-template-columns: 120px 1fr 120px;
 				gap: 1rem;
 
 				.logo-link {
@@ -230,11 +232,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 					</div>
 				}
 				if !UserInfo.IsLoggedIn {
-					<a
-						href="/auth"
-						class="btn btn--primary"
-						style="place-self: center end; margin-right:  1rem"
-					>
+					<a href="/auth" class="btn btn--primary">
 						Logg inn
 					</a>
 				}

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -170,7 +170,6 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			.main-menu {
 				grid-template-areas: 'logo navbuttons usermenu';
 				grid-template-columns: 120px 1fr 120px;
-				gap: 1rem;
 
 				.logo-link {
 					display: flex;

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -69,7 +69,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 
 		.main-menu-header {
 			width: 100%;
-			background-color: #2d3748;
+			background-color: var(--bg-surface);
 			box-shadow: 0 2px 4px hsla(0, 0%, 0%, 0.1);
 			position: fixed;
 			bottom: 0;
@@ -117,7 +117,6 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				position: relative;
 				display: block;
 				place-self: center end;
-				margin-inline-start: 0.7rem;
 			}
 
 			summary {
@@ -137,9 +136,11 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			.dropdown-panel {
 				position: absolute;
 				right: 0.5rem;
-				bottom: calc(var(--nav-height) + 0.5rem);
-				background-color: #2d3748;
+				top: 42px;
+				background-color: var(--bg-item);
+				border: 1px solid var(--bg-item-border);
 				box-shadow: 0 8px 16px hsla(0, 0%, 0%, 0.2);
+				border-radius: var(--border-radius-1x);
 				z-index: var(--nav-drop-down-z-index);
 			}
 
@@ -195,8 +196,11 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				}
 
 				.menu-btn {
-					margin-inline-end: 0.5rem;
-					height: 20px;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					height: 42px;
+					width: 42px;
 				}
 
 				.beta-toggle-label {
@@ -222,7 +226,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			</section>
 			<section id="main-menu-usermenu">
 				if UserInfo.IsLoggedIn {
-					<div style="display: flex; align-items: center; gap: 0.5rem; place-self: center end; margin-right: 1rem;">
+					<div style="display: flex; align-items: center; gap: 0.5rem; place-self: center end;">
 						<details class="menu-btn">
 							<summary>
 								@icons.Icon(icons.Menu, icons.Size24)

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -76,15 +76,14 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			z-index: var(--nav-z-index);
 		}
 		.main-menu {
-			display: grid;
-			grid-template-areas: 'logo navbuttons usermenu';
-			grid-template-columns: 100px 1fr 100px;
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-around;
 			height: var(--nav-height);
 			width: 100%;
-			gap: var(--nav-gap);
+			gap: var(--spacing-4x);
 			font-family: "Fira Code";
-			place-content: center;
-			place-items: center;
 
 			a.disabled {
 				pointer-events: none;
@@ -109,7 +108,6 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				list-style: none;
 				/* hide the default disclosure triangle in some browsers */
 				color: var(--color-secondary);
-				text-transform: uppercase;
 				text-decoration: none;
 			}
 
@@ -118,10 +116,24 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				/* hide default marker in Chrome/Safari */
 			}
 
+			.menu-btn {
+				display: flex;
+        flex-direction: column;
+				justify-content: center;
+				align-items: center;
+        font-size: 12px;
+        height: 48px;
+        padding: 0 var(--spacing-4x);
+        gap: var(--spacing-1x);
+        .menu-btn-text {
+          white-space: nowrap;
+    	  }
+			}
+
 			.dropdown-panel {
 				position: absolute;
-				right: 0.5rem;
-				top: 42px;
+				right: 0;
+				bottom: 52px;
 				background-color: var(--bg-item);
 				border: 1px solid var(--bg-item-border);
 				box-shadow: 0 8px 16px hsla(0, 0%, 0%, 0.2);
@@ -142,35 +154,51 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			}
 		}
 
-		@container main (width > 420px) {
+		#main-menu-logo {
+			display: none;
+		}
+
+		#main-menu-navbuttons {
+			display: contents;
+		}
+
+		.main-menu-buttons {
+			display: contents;
+		}
+
+		@container main (width > 600px) {
+			#main-menu-logo {
+				grid-area: logo;
+				display: flex;
+				justify-content: flex-start;
+				width: 100%;
+			}
+
+			#main-menu-navbuttons {
+				display: initial;
+				grid-area: navbuttons;
+				width: 100%;
+			}
+
+			#main-menu-usermenu {
+				grid-area: usermenu;
+				display: flex;
+				justify-content: flex-end;
+				width: 100%;
+			}
+
 			.main-menu-header {
 				position: sticky;
 				top: 0;
 				bottom: unset;
 			}
 
-			#main-menu-logo {
-				display: flex;
-				justify-content: flex-start;
-				width: 100%;
-				grid-area: logo;
-			}
-
-			#main-menu-navbuttons {
-				grid-area: navbuttons
-			}
-
-			#main-menu-usermenu {
-				display: flex;
-				justify-content: flex-end;
-				width: 100%;
-				grid-area: usermenu;
-			}
-
 			.main-menu {
+				display: grid;
 				grid-template-areas: 'logo navbuttons usermenu';
-				grid-template-columns: 120px 1fr 120px;
-
+				grid-template-columns: 50px 1fr 50px;
+				place-content: center;
+				place-items: center;
 				.logo-link {
 					display: flex;
 					place-items: center;
@@ -181,12 +209,29 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 					}
 				}
 
-				.menu-btn {
+				.menu-btn-container {
 					display: flex;
 					align-items: center;
 					justify-content: center;
 					height: 42px;
 					width: 42px;
+					.inline-icon {
+						width: 24px;
+						height: 24px;
+					}
+				}
+
+				.menu-btn {
+					height: var(--btn-height);
+					width: var(--btn-height);
+					padding: 0;
+					.menu-btn-text {
+						display: none;
+					}
+				}
+
+				.btn-login {
+					white-space: nowrap;
 				}
 
 				.beta-toggle-label {
@@ -195,8 +240,14 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 
 				.dropdown-panel {
 					bottom: unset;
-					min-inline-size: max-content;
+					top: 46px;
 				}
+			}
+		}
+
+		@container main (width > 800px) {
+			.main-menu {
+				grid-template-columns: 120px 1fr 120px;
 			}
 		}
 	</style>
@@ -213,9 +264,10 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			<section id="main-menu-usermenu">
 				if UserInfo.IsLoggedIn {
 					<div style="display: flex; align-items: center; gap: 0.5rem; place-self: center end;">
-						<details class="menu-btn">
-							<summary>
-								@icons.Icon(icons.Menu, icons.Size24)
+						<details class="menu-btn-container">
+							<summary class="btn btn--ghost menu-btn">
+								@icons.Icon(icons.Menu, icons.Size20)
+								<span class="menu-btn-text">Meny</span>
 							</summary>
 							<div class="dropdown-panel">
 								<a href="/auth/logout">Logg ut</a>
@@ -231,7 +283,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 					</div>
 				}
 				if !UserInfo.IsLoggedIn {
-					<a href="/auth" class="btn btn--primary">
+					<a href="/auth" class="btn btn--primary btn-login">
 						Logg inn
 					</a>
 				}

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -1,4 +1,4 @@
-package components
+package header
 
 import (
 	"github.com/Regncon/conorganizer/service/requestctx"

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -1,8 +1,8 @@
 package header
 
 import (
-	"github.com/Regncon/conorganizer/service/requestctx"
 	"github.com/Regncon/conorganizer/components/icons"
+	"github.com/Regncon/conorganizer/service/requestctx"
 )
 
 var beta = false
@@ -231,7 +231,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 								<a href="/auth/logout">Logg ut</a>
 								<a href="/my-events">Mine arrangementer</a>
 								if UserInfo.IsAdmin {
-																	<a href="/profile">Min Profil</a>
+									<a href="/profile">Min Profil</a>
 									<hr/>
 									<a href="/admin/billettholder/">Billettholderoversikt</a>
 									<a href="/admin/approval/">Arrangement til godkjenning</a>

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -77,7 +77,8 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 		}
 		.main-menu {
 			display: grid;
-			grid-template-columns: repeat(2, max-content);
+			grid-template-areas: 'logo navbuttons usermenu';
+			grid-template-columns: 100px 1fr 100px;
 			height: var(--nav-height);
 			width: 100%;
 			gap: var(--nav-gap);
@@ -162,8 +163,25 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				bottom: unset;
 			}
 
+			#main-menu-logo {
+				display: flex;
+				justify-content: flex-start;
+				grid-area: logo;
+			}
+
+			#main-menu-navbuttons {
+				grid-area: navbuttons
+			}
+
+			#main-menu-usermenu {
+				display: flex;
+				justify-content: flex-end;
+				grid-area: usermenu;
+			}
+
 			.main-menu {
-				grid-template-columns: max-content 1fr 1fr;
+				grid-template-areas: 'logo navbuttons usermenu';
+				grid-template-columns: 100px 1fr 100px;
 				gap: 1rem;
 
 				.logo-link {
@@ -173,22 +191,6 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 					img {
 						width: 3rem;
 						height: 3rem;
-					}
-				}
-
-				.main-menu-links {
-					place-self: center start;
-
-					.main-menu-link {
-						display: flex;
-						gap: 0.25rem;
-						justify-content: center;
-						align-items: center;
-						height: 100%;
-
-						.main-menu-link-text {
-							display: block;
-						}
 					}
 				}
 
@@ -210,45 +212,44 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 	</style>
 	<header class="main-menu-header">
 		<nav class="main-menu page-content-container wide-content">
-			<a href="/" class="logo-link">
-				<img src="/static/RegnconLogo.svg" alt="logo"/>
-			</a>
-			<section class="main-menu-links">
-				<a href="/" class="main-menu-link">
-					@icons.Icon(icons.Home, icons.Size24)
-					<span class="main-menu-link-text">
-						Hjem
-					</span>
+			<section id="main-menu-logo">
+				<a href="/" class="logo-link">
+					<img src="/static/RegnconLogo.svg" alt="logo"/>
 				</a>
 			</section>
-			if UserInfo.IsLoggedIn {
-				<div style="display: flex; align-items: center; gap: 0.5rem; place-self: center end; margin-right: 1rem;">
-					<details class="menu-btn">
-						<summary>
-							@icons.Icon(icons.Menu, icons.Size24)
-						</summary>
-						<div class="dropdown-panel">
-							<a href="/auth/logout">Logg ut</a>
-							<a href="/my-events">Mine arrangementer</a>
-							if UserInfo.IsAdmin {
-                                <a href="/profile">Min Profil</a>
-								<hr/>
-								<a href="/admin/billettholder/">Billettholderoversikt</a>
-								<a href="/admin/approval/">Arrangement til godkjenning</a>
-							}
-						</div>
-					</details>
-				</div>
-			}
-			if !UserInfo.IsLoggedIn {
-				<a
-					href="/auth"
-					class="btn btn--primary"
-					style="place-self: center end; margin-right:  1rem"
-				>
-					Logg inn
-				</a>
-			}
+			<section id="main-menu-navbuttons">
+				@MainMenuButtons(UserInfo)
+			</section>
+			<section id="main-menu-usermenu">
+				if UserInfo.IsLoggedIn {
+					<div style="display: flex; align-items: center; gap: 0.5rem; place-self: center end; margin-right: 1rem;">
+						<details class="menu-btn">
+							<summary>
+								@icons.Icon(icons.Menu, icons.Size24)
+							</summary>
+							<div class="dropdown-panel">
+								<a href="/auth/logout">Logg ut</a>
+								<a href="/my-events">Mine arrangementer</a>
+								if UserInfo.IsAdmin {
+																	<a href="/profile">Min Profil</a>
+									<hr/>
+									<a href="/admin/billettholder/">Billettholderoversikt</a>
+									<a href="/admin/approval/">Arrangement til godkjenning</a>
+								}
+							</div>
+						</details>
+					</div>
+				}
+				if !UserInfo.IsLoggedIn {
+					<a
+						href="/auth"
+						class="btn btn--primary"
+						style="place-self: center end; margin-right:  1rem"
+					>
+						Logg inn
+					</a>
+				}
+			</section>
 		</nav>
 	</header>
 }

--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -98,21 +98,6 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				display: none;
 			}
 
-			.main-menu-links {
-				.main-menu-link {
-					color: var(--color-secondary);
-					text-decoration: none;
-
-					.main-menu-link-text {
-						display: none;
-					}
-				}
-
-				.main-menu-link:hover {
-					background-color: hsla(0, 0%, 100%, 0.1);
-				}
-			}
-
 			details {
 				position: relative;
 				display: block;

--- a/components/icons/icon.templ
+++ b/components/icons/icon.templ
@@ -67,7 +67,7 @@ func getSVGContent(icon IconType) string {
 templ Icon(icon IconType, size IconSize) {
   {{
      svgContent := getSVGContent(icon) 
-     containerClass := fmt.Sprintf("icon-size-%s", size)
+     containerClass := fmt.Sprintf("inline-icon icon-size-%s", size)
   }}
   if svgContent != "" {
     <span class={containerClass}>

--- a/layouts/base.templ
+++ b/layouts/base.templ
@@ -1,7 +1,7 @@
 package layouts
 
 import (
-	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/components/header"
 	"github.com/Regncon/conorganizer/service/requestctx"
 )
 
@@ -25,7 +25,7 @@ templ Base(title string, userInfo requestctx.UserRequestInfo, children templ.Com
 		</head>
 		<body>
 			<main>
-				@components.Menu(userInfo)
+				@header.Menu(userInfo)
 				@children
 				<div class="page-footer"></div>
 			</main>

--- a/static/buttons.css
+++ b/static/buttons.css
@@ -2,7 +2,7 @@
     /* sizing */
     --btn-height: 42px;
     --btn-height-cta: 58px;
-    --btn-padding-x: var(--spacing-8x);
+    --btn-padding-x: var(--spacing-4x);
     --btn-font-size: 14px;
     --btn-font-weight: 600;
     --btn-border-radius: var(--border-radius-1x);

--- a/static/buttons.css
+++ b/static/buttons.css
@@ -225,3 +225,7 @@
     color: var(--btn-disabled-text);
     cursor: not-allowed;
 }
+
+.btn-with-icon {
+    gap: var(--spacing-2x);
+}

--- a/static/index.css
+++ b/static/index.css
@@ -27,6 +27,7 @@
     --bg-base: #1A1B26;
     --bg-surface: #252735;
     --bg-item: #35394A;
+    /* This is a border for surface and item both */
     --bg-item-border: #494D62;
 
     /* text & font */

--- a/static/index.css
+++ b/static/index.css
@@ -24,17 +24,10 @@
 
     --color-disabled: #CCD1E980;
 
-    --bg-base: var(--bg-body-100);
+    --bg-base: #1A1B26;
     --bg-surface: #252735;
-    --bg-item: var(--bg-body-90);
-    --bg-item-border: #494d62;
-
-    --bg-body-100: #1A1B26;
-    --bg-body-90: #35394A;
-    --bg-body-80: #474446;
-    --bg-body-70: #575255;
-    --bg-body-60: #666064;
-    --bg-body-50: #756e73;
+    --bg-item: #35394A;
+    --bg-item-border: #494D62;
 
     /* text & font */
     --text-body: 16px;


### PR DESCRIPTION
Oppdatering av knapper og ikoner i headeren, slik at hoved-knappene for navigering (hjem, min side, admin) er synlige og sentrert i headeren på siden. 

Dette oppdaterer også en del relaterte stiler og rydder litt i designet. Burde nok splitte mobil-navbaren og desktop-navbaren fra hverandre, for nå er koden litt knotet sammen .. men dette ser greit ut for nå.

<img width="1297" height="68" alt="image" src="https://github.com/user-attachments/assets/c77a6702-f99c-45c3-a1eb-34e50dd4e3c3" />

<img width="453" height="68" alt="image" src="https://github.com/user-attachments/assets/6972b145-aac4-4b59-b158-e39df579a952" />
