### PR TITLE
212 | Tidy frontpage app layout

### DIFF
--- a/components/header/menu.templ
+++ b/components/header/menu.templ
@@ -61,6 +61,7 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 			box-shadow: 0 2px 4px hsla(0, 0%, 0%, 0.1);
 			position: fixed;
 			bottom: 0;
+			border-top: 1px solid var(--bg-item-border);
 			z-index: var(--nav-z-index);
 		}
 		.main-menu {
@@ -179,6 +180,8 @@ templ Menu(UserInfo requestctx.UserRequestInfo) {
 				position: sticky;
 				top: 0;
 				bottom: unset;
+				border-top: none;
+				border-bottom: 1px solid var(--bg-item-border);
 			}
 
 			.main-menu {

--- a/pages/root/event_list.templ
+++ b/pages/root/event_list.templ
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/models"
 )
 
 type PuljeBlock struct {
@@ -126,25 +126,44 @@ templ eventPulje(pulje models.Pulje, byPulje EventsByPulje, eventImageDir *strin
 	if block == nil {
 		return
 	}
-	<h2
-		style="border-radius: var(--border-radius-2x);
-		       background-color: var(--bg-surface);
-		       padding: var(--spacing-5x);"
-		id={ pulje }
-	>
-		{ block.Pulje.Name }
-		{ block.Pulje.StartTime.Format("15:04") } – { block.Pulje.EndTime.Format("15:04") }
-	</h2>
-	<div style="margin-top: 1rem; display: grid; grid-template-columns: repeat(auto-fit,minmax(350px, 350px)); gap: 1rem;">
-		for _, event := range block.Events {
-			@components.EventCard(event, eventImageDir, isAdmin)
-		}
-	</div>
+	<section>
+		<h2 class="pulje-heading container-inner-padding" id={ pulje }>
+			{ block.Pulje.Name }
+			<span class="pulje-heading-time">({ block.Pulje.StartTime.Format("15:04") } – { block.Pulje.EndTime.Format("15:04") })</span>
+		</h2>
+		<div class="page-wide-eventcard-grid container-inner-padding">
+			for _, event := range block.Events {
+				@components.EventCard(event, eventImageDir, isAdmin)
+			}
+		</div>
+	</section>
 }
 
 templ eventList(db *sql.DB, isAdmin bool, eventImageDir *string) {
 	{{ eventsByPulje, err := GetEventsByPulje(db) }}
-	<div class="page-content-container">
+	<style>
+		.event-pulje-overview {
+			display: flex;
+			flex-direction: column;			
+			gap: var(--spacing-8x);
+		}
+		@container main (width > 600px) {
+			.event-pulje-overview	{
+				gap: var(--spacing-10x);
+			}
+		}
+
+		.pulje-heading {
+			color: var(--color-text-strong);
+			margin: 0 0 var(--spacing-5x);
+		}
+		.pulje-heading-time {
+			font-size: var(--text-body);
+			font-weight: normal;
+			color: var(--color-text-soft);
+		}
+	</style>
+	<div class="page-content-container event-pulje-overview">
 		if err != nil {
 			<p>Error fetching events: { err.Error() }</p>
 			return

--- a/pages/root/event_list.templ
+++ b/pages/root/event_list.templ
@@ -144,7 +144,7 @@ templ eventPulje(pulje models.Pulje, byPulje EventsByPulje, eventImageDir *strin
 
 templ eventList(db *sql.DB, isAdmin bool, eventImageDir *string) {
 	{{ eventsByPulje, err := GetEventsByPulje(db) }}
-	<div style="margin-right: auto; margin-left: auto; max-width: 1500px;">
+	<div class="page-content-container">
 		if err != nil {
 			<p>Error fetching events: { err.Error() }</p>
 			return

--- a/pages/root/event_list.templ
+++ b/pages/root/event_list.templ
@@ -126,7 +126,7 @@ templ eventPulje(pulje models.Pulje, byPulje EventsByPulje, eventImageDir *strin
 	if block == nil {
 		return
 	}
-	<section class="event-pulje-with-heading container-inner-padding">
+	<section class="container-inner-padding">
 		<h2 class="pulje-heading" id={ pulje }>
 			{ block.Pulje.Name }
 			<span class="pulje-heading-time">({ block.Pulje.StartTime.Format("15:04") } – { block.Pulje.EndTime.Format("15:04") })</span>
@@ -153,20 +153,9 @@ templ eventList(db *sql.DB, isAdmin bool, eventImageDir *string) {
 			}
 		}
 
-		.event-pulje-with-heading {
-			display: flex;
-			flex-direction: column;
-			gap: var(--spacing-3x);
-		}
 		.pulje-heading {
-			position: sticky;
-			top: var(--nav-height);
-			/* This is cursed but it gives padding to the heading when sticked without breaking the layout */
-			margin: calc(0px - var(--spacing-2x)) calc(0px - var(--spacing-2x)) 0;
-			padding: var(--spacing-2x) var(--spacing-2x);
 			color: var(--color-text-strong);
-			background-color: var(--bg-base);
-			z-index: var(--pulje-sticky-heading);
+			margin: 0 0 var(--spacing-5x);
 		}
 		.pulje-heading-time {
 			font-size: var(--text-body);

--- a/pages/root/event_list.templ
+++ b/pages/root/event_list.templ
@@ -126,12 +126,12 @@ templ eventPulje(pulje models.Pulje, byPulje EventsByPulje, eventImageDir *strin
 	if block == nil {
 		return
 	}
-	<section>
-		<h2 class="pulje-heading container-inner-padding" id={ pulje }>
+	<section class="event-pulje-with-heading container-inner-padding">
+		<h2 class="pulje-heading" id={ pulje }>
 			{ block.Pulje.Name }
 			<span class="pulje-heading-time">({ block.Pulje.StartTime.Format("15:04") } – { block.Pulje.EndTime.Format("15:04") })</span>
 		</h2>
-		<div class="page-wide-eventcard-grid container-inner-padding">
+		<div class="page-wide-eventcard-grid">
 			for _, event := range block.Events {
 				@components.EventCard(event, eventImageDir, isAdmin)
 			}
@@ -153,9 +153,20 @@ templ eventList(db *sql.DB, isAdmin bool, eventImageDir *string) {
 			}
 		}
 
+		.event-pulje-with-heading {
+			display: flex;
+			flex-direction: column;
+			gap: var(--spacing-3x);
+		}
 		.pulje-heading {
+			position: sticky;
+			top: var(--nav-height);
+			/* This is cursed but it gives padding to the heading when sticked without breaking the layout */
+			margin: calc(0px - var(--spacing-2x)) calc(0px - var(--spacing-2x)) 0;
+			padding: var(--spacing-2x) var(--spacing-2x);
 			color: var(--color-text-strong);
-			margin: 0 0 var(--spacing-5x);
+			background-color: var(--bg-base);
+			z-index: var(--pulje-sticky-heading);
 		}
 		.pulje-heading-time {
 			font-size: var(--text-body);

--- a/static/css/card.css
+++ b/static/css/card.css
@@ -1,7 +1,7 @@
 .event-card-container {
     display: grid;
     grid-template-rows: 180px minmax(110px, 1fr) min-content;
-    grid-template-columns: minmax(var(--mobile-min-width), 1fr);
+    grid-template-columns: minmax(300px, 1fr); /* min-width to fit smallest mobile size */
     color: var(--color-primary-text);
     background-color: var(--bg-surface);
     border-radius: var(--border-radius-1x);

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -3,10 +3,10 @@
   limiting it to a max 1440px width. With reducing margins as screen size narrows.
  */
 .page-content-container {
-  width: 100%;
-  max-width: var(--page-content-max-width);
-  padding: 0 var(--spacing-2x);
-  margin: 0 auto;
+    width: 100%;
+    max-width: var(--page-content-max-width);
+    padding: 0 var(--spacing-2x);
+    margin: 0 auto;
 }
 
 /* 
@@ -14,7 +14,7 @@
   limiting it to a max 1440px width. With reducing margins as screen size narrows.
  */
 .page-content-container.wide-content {
-  max-width: var(--page-content-wide-max-width);
+    max-width: var(--page-content-wide-max-width);
 }
 
 /*
@@ -22,17 +22,46 @@
   event preview enabled renders at this resolution.
  */
 .page-content-container.ultrawide-content {
-  max-width: var(--page-content-ultrawide-max-width);
+    max-width: var(--page-content-ultrawide-max-width);
+}
+
+/*
+  Dynamically adds extra padding for containers that should be 80px from the 1400px
+  container edge, scaling down to be 0 for mobile display sizes. Such as the frontpage
+  card grid.
+*/
+.container-inner-padding {
+  padding: 0;
 }
 
 @container main (width > 600px) {
-  .page-content-container {
-    padding: 0 var(--spacing-5x);
+    .page-content-container,
+    .container-inner-padding  {
+        padding: 0 var(--spacing-5x);
+    }
+}
+
+@container main (width > 1200px) {
+    .page-content-container,
+    .container-inner-padding  {
+        padding: 0 var(--spacing-10x);
+    }
+}
+
+.page-wide-eventcard-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+@container main (width > 720px) {
+  .page-wide-eventcard-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @container main (width > 1200px) {
-  .page-content-container {
-    padding: 0 var(--spacing-10x);
+  .page-wide-eventcard-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }

--- a/static/index.css
+++ b/static/index.css
@@ -64,7 +64,10 @@
 
     /* nav */
     --nav-height: 4rem;
-    --nav-z-index: 10;
+    
+    /* z-index */
+    --pulje-sticky-heading: 10;
+    --nav-z-index: 50;
 
     /* responsively size gap between panes in the same column of content */
     --responsive-pane-column-spacing: var(--spacing-4x);

--- a/static/index.css
+++ b/static/index.css
@@ -66,8 +66,8 @@
     --nav-height: 4rem;
     
     /* z-index */
-    --pulje-sticky-heading: 10;
     --nav-z-index: 50;
+    --subnav-z-index: 10;
 
     /* responsively size gap between panes in the same column of content */
     --responsive-pane-column-spacing: var(--spacing-4x);


### PR DESCRIPTION
Litt rydding i pulje-layoutet på forsiden.

La også til en manglende border på headeren, for både desktop og mobile.

<img width="2721" height="1256" alt="image" src="https://github.com/user-attachments/assets/0b4445d5-9819-4f8d-859d-eb97ee36de0e" />

<img width="378" height="756" alt="image" src="https://github.com/user-attachments/assets/14d7baf9-9044-433e-b042-4a44004b6000" />
