### PR TITLE
Quick-fix element spacing in interest modal

### DIFF
--- a/components/event_components/event_interests.templ
+++ b/components/event_components/event_interests.templ
@@ -80,8 +80,7 @@ templ EventInterests(userInfo requestctx.UserRequestInfo,
 
 				.dialog-content {
 					display: flex;
-					flex-direction: column;
-					gap: var(--responsive-pane-padding);
+					flex-direction: column;					
 					max-height: calc(100vh - 280px);
 					overflow: auto;
 

--- a/components/ticket_holder/ticket_holder_picker.templ
+++ b/components/ticket_holder/ticket_holder_picker.templ
@@ -28,6 +28,9 @@ import (
 
 templ TicketHolderPicker(userInfo requestctx.UserRequestInfo, eventId string, db *sql.DB, logger *slog.Logger) {
 	<style>
+		.ticket-holder-container {
+			padding-bottom: var(--responsive-pane-padding);
+		}
 		.ticket-holder-picker-buttons {
 			display: flex;
 			flex-direction: column;
@@ -53,7 +56,9 @@ templ TicketHolderPicker(userInfo requestctx.UserRequestInfo, eventId string, db
 	</style>
 	{{ associatedTicketHolders, err := GetTicketHolders(userInfo, db, logger) }}
 	if err != nil {
-		<p>Feil ved henting av billettholdere: { err.Error() }</p>
+		<div class="ticket-holder-container">
+			<p>Feil ved henting av billettholdere: { err.Error() }</p>
+		</div>
 	}
 	if len(associatedTicketHolders) == 0 {
 		<div
@@ -66,7 +71,7 @@ templ TicketHolderPicker(userInfo requestctx.UserRequestInfo, eventId string, db
 		<div data-signals-foo="1"></div>
 	}
 	if (len(associatedTicketHolders) > 1) {
-		<div>
+		<div class="ticket-holder-container">
 			<p class="label">Velg billettholder</p>
 			<div class="ticket-holder-picker-buttons">
 				for _, billettHolder := range associatedTicketHolders {

--- a/components/ticket_holder/ticket_holder_pulje_picker.templ
+++ b/components/ticket_holder/ticket_holder_pulje_picker.templ
@@ -11,6 +11,9 @@ import (
 templ TicketHolderPuljePicker(eventId string, puljeId string, db *sql.DB, logger *slog.Logger) {
     {{ puljer, _ := GetPuljerFromEventId(eventId, db, logger) }}
 	<style>
+        .pulje-picker-container {
+            padding-bottom: var(--responsive-pane-padding);
+        }
         .pulje-wrapper {
             display: grid;
             grid-template-columns: 1fr 1fr;
@@ -44,7 +47,7 @@ templ TicketHolderPuljePicker(eventId string, puljeId string, db *sql.DB, logger
     </style>
     {{fmt.Println(puljer)}}
     if (len(puljer) > 1) {
-        <div>
+        <div class="pulje-picker-container">
             <p class="label">Velg pulje for arrangementet</p>
             <div class="pulje-wrapper">
                 <button


### PR DESCRIPTION
Skjedde litt issues med spacing i interessemodalen etter at signals ble lagt in der, så jeg bare patcher rundt det ved å bruke padding under de dynamiske komponentene.

<img width="552" height="332" alt="image" src="https://github.com/user-attachments/assets/64377ee4-38f2-4d6f-9606-4a326024e02a" />
