### PR TITLE
00 | fix onload overriding between scripts

### DIFF
--- a/layouts/base.templ
+++ b/layouts/base.templ
@@ -13,8 +13,8 @@ templ Base(title string, userInfo requestctx.UserRequestInfo, children templ.Com
 			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>
 			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-			<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Fira+Code:wght@300..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="preload" as="style">
-			<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Fira+Code:wght@300..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+			<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Fira+Code:wght@300..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="preload" as="style"/>
+			<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Fira+Code:wght@300..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet"/>
 			<link rel="icon" type="image/x-icon" href="/static/favicon.ico"/>
 			<script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
 			<link rel="stylesheet" href="https://unpkg.com/tippy.js@5/dist/backdrop.css"/>
@@ -26,11 +26,11 @@ templ Base(title string, userInfo requestctx.UserRequestInfo, children templ.Com
 			<script src="https://unpkg.com/popper.js@1"></script>
 			<script src="https://unpkg.com/tippy.js@5"></script>
 			<script>
-				window.onload = function () {
+				window.addEventListener('load', function () {
 					tippy("[data-tippy-content]", {
 						animation: "scale-subtle",
 					});
-				};
+				}, false);
 			</script>
 		</head>
 		<body>

--- a/static/web_components/scroll_highlighter.js
+++ b/static/web_components/scroll_highlighter.js
@@ -1,9 +1,9 @@
 let sections = [];
 
-window.onload = function () {
+window.addEventListener('load', function () {
   sections = document.querySelectorAll(".program-pulje-section[id]");
   window.addEventListener("scroll", navHighlighter);
-}
+}, false);
 
 function navHighlighter() {
   let scrollY = window.pageYOffset;


### PR DESCRIPTION
Liten endring fra `onload` til `addEventListener('load')` for å ha en mer stabil lasting av JS-moduler som er avhenging av elementer lastet inn på siden.