### PR TITLE
Add functionality for supporting rooms

### DIFF
--- a/models/rooms.go
+++ b/models/rooms.go
@@ -9,3 +9,12 @@ type Room struct {
 	Notes               string `json:"note"`
 	IsDisabled          bool   `json:"is_disabled"`
 }
+
+type RoomByPulje struct {
+	ID                  int
+	Name                string
+	RoomNumber          string
+	Events              []EventPulje
+	Notes               string
+	MaxConcurrentEvents int
+}

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -47,6 +47,21 @@ type RoomByPulje struct {
 	Notes              string
 }
 
+// Helper function for getting currently assigned events to a room in a pulje
+func (r RoomByPulje) CurrentOccupancy() int {
+	return len(r.AssignedEventsID)
+}
+
+// Helper function for getting available free slots for a room in a pulje
+func (r RoomByPulje) RemainingCapacity() int {
+	return r.MaxConcurrentGames - len(r.AssignedEventsID)
+}
+
+// Helper function for quickly checking if a room is full in a pulje
+func (r RoomByPulje) IsFull() bool {
+	return len(r.AssignedEventsID) >= r.MaxConcurrentGames
+}
+
 // RoomStatusByPulje is a map of puljer containing room statuses, such as which games are assigned to that room
 // You can access status by keys: [Pulje][RoomID]
 type RoomStatusByPulje = map[Pulje]map[int64]RoomByPulje

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -39,7 +39,7 @@ type RoomEventPuljeSummary struct {
 // out what `max_concurrent_events` is based on a pulje, but also for the dropdown input component
 // used in assigning rooms to an event in a pulje
 type RoomByPulje struct {
-	ID                 int
+	ID                 int64
 	Name               string
 	RoomNumber         string
 	AssignedEventsID   []RoomEventPuljeSummary

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -1,18 +1,6 @@
 package models
 
-// Room is the internal struct of a room
 type Room struct {
-	ID                  int
-	Name                string
-	RoomNumber          string
-	Floor               int
-	MaxConcurrentEvents int
-	Notes               string
-	IsDisabled          bool
-}
-
-// RoomJSON is the JSON representation of `Room` type for use with db query and front-end
-type RoomJSON struct {
 	ID                  int    `json:"id"`
 	Name                string `json:"name"`
 	RoomNumber          string `json:"room_number"`

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -1,20 +1,47 @@
 package models
 
+// Room is the internal struct of a room
 type Room struct {
+	ID                  int
+	Name                string
+	RoomNumber          string
+	Floor               int
+	MaxConcurrentEvents int
+	Notes               string
+	IsDisabled          bool
+}
+
+// RoomJSON is the JSON representation of `Room` type for use with db query and front-end
+type RoomJSON struct {
 	ID                  int    `json:"id"`
 	Name                string `json:"name"`
 	RoomNumber          string `json:"room_number"`
 	Floor               int    `json:"floor"`
 	MaxConcurrentEvents int    `json:"max_concurrent_events"`
-	Notes               string `json:"note"`
+	Notes               string `json:"notes"`
 	IsDisabled          bool   `json:"is_disabled"`
 }
 
+/*
+RoomEventPuljeSummary is the summary of an event in `relation_event_puljer` and used in `RoomByPulje` struct
+  - `EventPuljeID` is the ID of the unique event in a pulje
+  - `EventID`      is the ID of the pulje the unique event is in
+  - `Title`        is the title of the event
+*/
+type RoomEventPuljeSummary struct {
+	EventPuljeID string
+	EventID      string
+	Title        string
+}
+
+// RoomByPulje is a snapshot of room delegation for a specific pulje, this is mainly used for figuring
+// out what `max_concurrent_events` is based on a pulje, but also for the dropdown input component
+// used in assigning rooms to an event in a pulje
 type RoomByPulje struct {
 	ID                  int
 	Name                string
 	RoomNumber          string
-	Events              []EventPulje
-	Notes               string
+	AssignedEventsID    []RoomEventPuljeSummary
 	MaxConcurrentEvents int
+	Notes               string
 }

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -1,0 +1,11 @@
+package models
+
+type Room struct {
+	ID                  int    `json:"id"`
+	Name                string `json:"name"`
+	RoomNumber          string `json:"room_number"`
+	Floor               int    `json:"floor"`
+	MaxConcurrentEvents int    `json:"max_concurrent_events"`
+	Notes               string `json:"note"`
+	IsDisabled          bool   `json:"is_disabled"`
+}

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -44,3 +44,7 @@ type RoomByPulje struct {
 	MaxConcurrentGames int
 	Notes              string
 }
+
+// RoomStatusByPulje is a map of puljer containing room statuses, such as which games are assigned to that room
+// You can access status by keys: [Pulje][RoomID]
+type RoomStatusByPulje = map[Pulje]map[int64]RoomByPulje

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -1,13 +1,13 @@
 package models
 
 type Room struct {
-	ID                  int    `json:"id"`
-	Name                string `json:"name"`
-	RoomNumber          string `json:"room_number"`
-	Floor               int    `json:"floor"`
-	MaxConcurrentEvents int    `json:"max_concurrent_events"`
-	Notes               string `json:"notes"`
-	IsDisabled          bool   `json:"is_disabled"`
+	ID                 int    `json:"id"`
+	Name               string `json:"name"`
+	RoomNumber         string `json:"room_number"`
+	Floor              int    `json:"floor"`
+	MaxConcurrentGames int    `json:"max_concurrent_games"`
+	Notes              string `json:"notes"`
+	IsDisabled         bool   `json:"is_disabled"`
 }
 
 /*
@@ -26,10 +26,10 @@ type RoomEventPuljeSummary struct {
 // out what `max_concurrent_events` is based on a pulje, but also for the dropdown input component
 // used in assigning rooms to an event in a pulje
 type RoomByPulje struct {
-	ID                  int
-	Name                string
-	RoomNumber          string
-	AssignedEventsID    []RoomEventPuljeSummary
-	MaxConcurrentEvents int
-	Notes               string
+	ID                 int
+	Name               string
+	RoomNumber         string
+	AssignedEventsID   []RoomEventPuljeSummary
+	MaxConcurrentGames int
+	Notes              string
 }

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -10,6 +10,17 @@ type Room struct {
 	IsDisabled         bool   `json:"is_disabled"`
 }
 
+// Normalized version of `Room` type for use when updating a room, or quering for a specific room with optional params
+type RoomInput struct {
+	ID                 int
+	Name               *string
+	RoomNumber         *string
+	Floor              *int
+	MaxConcurrentGames *int
+	Notes              *string
+	IsDisabled         *bool
+}
+
 /*
 RoomEventPuljeSummary is the summary of an event in `relation_event_puljer` and used in `RoomByPulje` struct
   - `EventPuljeID` is the ID of the unique event in a pulje

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -1,5 +1,7 @@
 package models
 
+import "database/sql"
+
 type Room struct {
 	ID                 int    `json:"id"`
 	Name               string `json:"name"`
@@ -48,3 +50,16 @@ type RoomByPulje struct {
 // RoomStatusByPulje is a map of puljer containing room statuses, such as which games are assigned to that room
 // You can access status by keys: [Pulje][RoomID]
 type RoomStatusByPulje = map[Pulje]map[int64]RoomByPulje
+
+type RoomStatusRow struct {
+	PuljeID Pulje
+
+	RoomID             int64
+	RoomName           string
+	RoomNumber         string
+	MaxConcurrentGames int
+	RoomNotes          string
+
+	EventID    sql.NullString
+	EventTitle sql.NullString
+}

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -261,7 +261,55 @@ func GetRoomByID(db *sql.DB, roomID int) (*models.Room, error) {
 }
 
 // GetAllRooms returns a list of all rooms stored in DB
-func GetAllRooms(db *sql.DB) {}
+func GetAllRooms(db *sql.DB) ([]*models.Room, error) {
+	query := `
+		SELECT
+			id,
+			name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled
+		FROM rooms
+		ORDER BY floor ASC, room_number ASC
+	`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rooms: %w", err)
+	}
+	defer rows.Close()
+
+	var rooms []*models.Room
+
+	for rows.Next() {
+
+		var room models.Room
+
+		err := rows.Scan(
+			&room.ID,
+			&room.Name,
+			&room.RoomNumber,
+			&room.Floor,
+			&room.MaxConcurrentGames,
+			&room.Notes,
+			&room.IsDisabled,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan room: %w", err)
+		}
+
+		rooms = append(rooms, &room)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error while iterating rooms: %w", err)
+	}
+
+	return rooms, nil
+}
 
 // GetAllRoomStatusesByPuljeID Generates a list of all rooms, but unique to a pulje
 func GetAllRoomStatusesByPuljeID(db *sql.DB, puljeID string) {

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -14,7 +14,7 @@ func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 		return nil, fmt.Errorf("Room number is required")
 	}
 
-	// We can disable this check if we want
+	// We can disable this check if we want, if so, remember to update test
 	if !strings.HasPrefix(data.RoomNumber, fmt.Sprintf("%d", data.Floor)) {
 		return nil, fmt.Errorf(
 			"Room number must start with the floor number, eg: %dxx, got: %s",
@@ -53,8 +53,114 @@ func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 	return &data, nil
 }
 
-// UpdateRoom updates a room based on its ID
-func UpdateRoom(db *sql.DB, data models.Room) {}
+// UpdateRoom updates a room based on its ID with partial new information
+func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) {
+	if data.ID < 1 {
+		return nil, fmt.Errorf("Room ID is required and must be a valid positive number")
+	}
+
+	// Set up params based on partial data
+	setParts := []string{}
+	args := []any{}
+
+	if data.Name != nil {
+		if strings.TrimSpace(*data.Name) == "" {
+			return nil, fmt.Errorf("room name cannot be empty")
+		}
+
+		setParts = append(setParts, "name = ?")
+		args = append(args, *data.Name)
+	}
+
+	if data.RoomNumber != nil {
+		if strings.TrimSpace(*data.RoomNumber) == "" {
+			return nil, fmt.Errorf("room number cannot be empty")
+		}
+
+		setParts = append(setParts, "room_number = ?")
+		args = append(args, *data.RoomNumber)
+	}
+
+	if data.Floor != nil {
+		setParts = append(setParts, "floor = ?")
+		args = append(args, *data.Floor)
+	}
+
+	if data.MaxConcurrentGames != nil {
+		if *data.MaxConcurrentGames < 1 {
+			return nil, fmt.Errorf("max concurrent games must be greater than 0")
+		}
+
+		setParts = append(setParts, "max_concurrent_games = ?")
+		args = append(args, *data.MaxConcurrentGames)
+	}
+
+	if data.Notes != nil {
+		setParts = append(setParts, "notes = ?")
+		args = append(args, *data.Notes)
+	}
+
+	if data.IsDisabled != nil {
+		setParts = append(setParts, "is_disabled = ?")
+		args = append(args, *data.IsDisabled)
+	}
+
+	if len(args) == 0 {
+		return nil, fmt.Errorf("Update room called without any updated data")
+	}
+
+	// Construct query based on partial data
+	query := fmt.Sprintf(`
+		UPDATE rooms
+		SET %s
+		WHERE id = ?
+        RETURNING
+			id,
+			name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled;
+	`, strings.Join(setParts, ", "))
+
+	// Construct args based on partial data
+	args = append(args, data.ID)
+
+	_, err := db.Exec(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update room: %w", err)
+	}
+
+	var updated models.Room
+
+	err = db.QueryRow(`
+		SELECT
+			id,
+			name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled
+		FROM rooms
+		WHERE id = ?
+	`, data.ID).Scan(
+		&updated.ID,
+		&updated.Name,
+		&updated.RoomNumber,
+		&updated.Floor,
+		&updated.MaxConcurrentGames,
+		&updated.Notes,
+		&updated.IsDisabled,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch updated room: %w", err)
+	}
+
+	return &updated, nil
+}
 
 // GetRoomByID returns a room pointer based on a roomID
 func GetRoomByID(db *sql.DB, roomID int) {}

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -1,0 +1,31 @@
+package rooms
+
+import (
+	"database/sql"
+
+	"github.com/Regncon/conorganizer/models"
+)
+
+// CreateRoom creates a room
+func CreateRoom(db *sql.DB, data models.Room)
+
+// UpdateRoom updates a room based on its ID
+func UpdateRoom(db *sql.DB, data models.Room)
+
+// GetRoomByID returns a room pointer based on a roomID
+func GetRoomByID(db *sql.DB, roomID string)
+
+// GetAllRooms returns a list of all rooms stored in DB
+func GetAllRooms(db *sql.DB)
+
+// GetAllRoomStatusesByPuljeID Generates a list of all rooms, but unique to a pulje
+func GetAllRoomStatusesByPuljeID(db *sql.DB, puljeID string) {
+	// This function needs to return a detailed overview of available rooms, where
+	// assigned events are limited to pulje
+}
+
+// SetRelationEventPuljeRoom assigns a room to an event in event_puljer_relation table
+func AssignRoomToRelationEventPuljer(db *sql.DB, roomID string, relationEventPuljeID string) {
+	// This function will assign a room by id to an event in event_puljer_relation
+	// Validate that the room does not exceed max events based on pulje?
+}

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -452,7 +452,3 @@ func AssignRoomToRelationEventPuljer(db *sql.DB, roomID int64, relationEventPulj
 
 	return result, nil
 }
-
-func GetRelationEventPuljerByRoomIDAndPuljeID(db *sql.DB, roomID int, puljeID string) {
-	// This functino will return all events assigned to a room limited by the pulje
-}

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -2,28 +2,72 @@ package rooms
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 
 	"github.com/Regncon/conorganizer/models"
 )
 
-// CreateRoom creates a room
-func CreateRoom(db *sql.DB, data models.Room)
+// CreateRoom creates a room, on success updates `ID` with its entry ID
+func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
+	if strings.TrimSpace(data.RoomNumber) == "" {
+		return nil, fmt.Errorf("Room number is required")
+	}
+
+	// We can disable this check if we want
+	if !strings.HasPrefix(data.RoomNumber, fmt.Sprintf("%d", data.Floor)) {
+		return nil, fmt.Errorf(
+			"Room number must start with the floor number, eg: %dxx, got: %s",
+			data.Floor,
+			data.RoomNumber,
+		)
+	}
+
+	if data.MaxConcurrentGames < 1 {
+		return nil, fmt.Errorf("Max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
+	}
+
+	query := `
+        INSERT INTO rooms (
+            name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+    `
+
+	result, err := db.Exec(query, data.Name, data.RoomNumber, data.Floor, data.MaxConcurrentGames, data.Notes, data.IsDisabled)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create room: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get created room id: %w", err)
+	}
+
+	data.ID = int(id)
+	return &data, nil
+}
 
 // UpdateRoom updates a room based on its ID
-func UpdateRoom(db *sql.DB, data models.Room)
+func UpdateRoom(db *sql.DB, data models.Room) {}
 
 // GetRoomByID returns a room pointer based on a roomID
-func GetRoomByID(db *sql.DB, roomID int)
+func GetRoomByID(db *sql.DB, roomID int) {}
 
 // GetAllRooms returns a list of all rooms stored in DB
-func GetAllRooms(db *sql.DB)
+func GetAllRooms(db *sql.DB) {}
 
 // GetAllRoomStatusesByPuljeID Generates a list of all rooms, but unique to a pulje
 func GetAllRoomStatusesByPuljeID(db *sql.DB, puljeID string) {
 	// This function needs to return a detailed overview of available rooms, where
 	// assigned events are limited to pulje
 
-	// Should this include complete events or just convert this to a number?
+	// Should this include complete events from event puljer, just event puljer id or just convert this to a number?
 }
 
 // SetRelationEventPuljeRoom assigns a room to an event in `relation_event_puljer`

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -312,12 +312,106 @@ func GetAllRooms(db *sql.DB) ([]*models.Room, error) {
 }
 
 // GetAllRoomStatusesByPulje Generates a list of all rooms, but unique to a pulje
-func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) ([]*models.RoomEventPuljeSummary, error) {
+func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatusByPulje, error) {
 	// This function needs to return a detailed overview of available rooms, where
 	// assigned events are limited to pulje
+	query := `
+        SELECT
+            p.id,
 
-	// Should this include complete events from event puljer, just event puljer id or just convert this to a number?
-	return nil, nil
+            r.id,
+            r.name,
+            r.room_number,
+            r.max_concurrent_games,
+            r.notes,
+
+            e.id,
+            e.title
+        FROM puljer p
+        CROSS JOIN rooms r
+        LEFT JOIN relation_event_puljer rep
+            ON rep.pulje_id = p.id
+            AND rep.room_id = r.id
+            AND rep.is_in_pulje = 1
+        LEFT JOIN events e
+            ON e.id = rep.event_id
+        WHERE
+            r.is_disabled = 0
+        ORDER BY
+            p.id,
+            r.floor,
+            r.room_number,
+            e.title;
+        `
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rooms statuses: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(models.RoomStatusByPulje)
+	for rows.Next() {
+		var row models.RoomStatusRow
+
+		err := rows.Scan(
+			&row.PuljeID,
+
+			&row.RoomID,
+			&row.RoomName,
+			&row.RoomNumber,
+			&row.MaxConcurrentGames,
+			&row.RoomNotes,
+
+			&row.EventID,
+			&row.EventTitle,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan room status row: %w", err)
+		}
+
+		// Ensure pulje exists
+		if _, exists := result[row.PuljeID]; !exists {
+			result[row.PuljeID] = make(map[int64]models.RoomByPulje)
+		}
+
+		// Create room if it doesn't exist yet
+		room, exists := result[row.PuljeID][row.RoomID]
+		if !exists {
+			room = models.RoomByPulje{
+				ID:                 int(row.RoomID),
+				Name:               row.RoomName,
+				RoomNumber:         row.RoomNumber,
+				MaxConcurrentGames: row.MaxConcurrentGames,
+				Notes:              row.RoomNotes,
+				AssignedEventsID:   []models.RoomEventPuljeSummary{},
+			}
+		}
+
+		// Add event if assigned
+		if row.EventID.Valid {
+			room.AssignedEventsID = append(
+				room.AssignedEventsID,
+				models.RoomEventPuljeSummary{
+					EventPuljeID: fmt.Sprintf(
+						"%s:%s",
+						row.EventID.String,
+						row.PuljeID,
+					),
+					EventID: row.EventID.String,
+					Title:   row.EventTitle.String,
+				},
+			)
+		}
+
+		result[row.PuljeID][row.RoomID] = room
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate room status rows: %w", err)
+	}
+
+	return result, nil
 }
 
 // SetRelationEventPuljeRoom assigns a room to an event in `relation_event_puljer`

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -12,20 +12,20 @@ import (
 // CreateRoom creates a room, on success updates `ID` with its entry ID
 func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 	if strings.TrimSpace(data.RoomNumber) == "" {
-		return nil, fmt.Errorf("Room number is required")
+		return nil, fmt.Errorf("room number is required")
 	}
 
 	// We can disable this check if we want, if so, remember to update test
 	if !strings.HasPrefix(data.RoomNumber, fmt.Sprintf("%d", data.Floor)) {
 		return nil, fmt.Errorf(
-			"Room number must start with the floor number, eg: %dxx, got: %s",
+			"room number must start with the floor number, eg: %dxx, got: %s",
 			data.Floor,
 			data.RoomNumber,
 		)
 	}
 
 	if data.MaxConcurrentGames < 1 {
-		return nil, fmt.Errorf("Max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
+		return nil, fmt.Errorf("max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
 	}
 
 	query := `
@@ -42,12 +42,12 @@ func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 
 	result, err := db.Exec(query, data.Name, data.RoomNumber, data.Floor, data.MaxConcurrentGames, data.Notes, data.IsDisabled)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create room: %w", err)
+		return nil, fmt.Errorf("failed to create room: %w", err)
 	}
 
 	id, err := result.LastInsertId()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get created room id: %w", err)
+		return nil, fmt.Errorf("failed to get created room id: %w", err)
 	}
 
 	data.ID = int(id)
@@ -57,20 +57,20 @@ func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 // UpdateRoom updates a room based on its ID with new Room type data
 func UpdateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 	if strings.TrimSpace(data.RoomNumber) == "" {
-		return nil, fmt.Errorf("Room number is required")
+		return nil, fmt.Errorf("room number is required")
 	}
 
 	// We can disable this check if we want, if so, remember to update test
 	if !strings.HasPrefix(data.RoomNumber, fmt.Sprintf("%d", data.Floor)) {
 		return nil, fmt.Errorf(
-			"Room number must start with the floor number, eg: %dxx, got: %s",
+			"room number must start with the floor number, eg: %dxx, got: %s",
 			data.Floor,
 			data.RoomNumber,
 		)
 	}
 
 	if data.MaxConcurrentGames < 1 {
-		return nil, fmt.Errorf("Max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
+		return nil, fmt.Errorf("max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
 	}
 
 	query := `
@@ -111,7 +111,7 @@ func UpdateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 // UpdateRoom updates a room based on its ID with partial new information
 func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) {
 	if data.ID < 1 {
-		return nil, fmt.Errorf("Room ID is required and must be a valid positive number")
+		return nil, fmt.Errorf("room ID is required and must be a valid positive number")
 	}
 
 	// Set up params based on partial data
@@ -161,7 +161,7 @@ func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) 
 	}
 
 	if len(args) == 0 {
-		return nil, fmt.Errorf("Update room called without any updated data")
+		return nil, fmt.Errorf("update room called without any updated data")
 	}
 
 	// Construct query based on partial data
@@ -445,7 +445,7 @@ func AssignRoomToRelationEventPuljer(db *sql.DB, roomID int64, relationEventPulj
 			)
 		}
 		return models.EventPulje{}, fmt.Errorf(
-			"Error assigning room to relation_event_puljer: %w",
+			"error assigning room to relation_event_puljer: %w",
 			err,
 		)
 	}

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -379,7 +379,7 @@ func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatu
 		room, exists := result[row.PuljeID][row.RoomID]
 		if !exists {
 			room = models.RoomByPulje{
-				ID:                 int(row.RoomID),
+				ID:                 row.RoomID,
 				Name:               row.RoomName,
 				RoomNumber:         row.RoomNumber,
 				MaxConcurrentGames: row.MaxConcurrentGames,
@@ -415,11 +415,42 @@ func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatu
 }
 
 // SetRelationEventPuljeRoom assigns a room to an event in `relation_event_puljer`
-func AssignRoomToRelationEventPuljer(db *sql.DB, roomID int, relationEventPuljeID string) {
-	// This function will assign a room by id to an event in relation_event_puljer
-	// Validate that the room does not exceed max events based on pulje?
+func AssignRoomToRelationEventPuljer(db *sql.DB, roomID int64, relationEventPuljeID string) (models.EventPulje, error) {
+	query := `
+		UPDATE relation_event_puljer
+		SET room_id = ?
+		WHERE event_id = ?
+		RETURNING
+			event_id,
+			pulje_id,
+			is_in_pulje,
+			is_published,
+			room_id
+	`
 
-	// Move this function to event pujer as parent...
+	var result models.EventPulje
+	err := db.QueryRow(query, roomID, relationEventPuljeID).Scan(
+		&result.EventID,
+		&result.PuljeID,
+		&result.IsInPulje,
+		&result.IsPublished,
+		&result.RoomID,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return models.EventPulje{}, fmt.Errorf(
+				"no relation_event_puljer found for event_id=%s",
+				relationEventPuljeID,
+			)
+		}
+		return models.EventPulje{}, fmt.Errorf(
+			"Error assigning room to relation_event_puljer: %w",
+			err,
+		)
+	}
+
+	return result, nil
 }
 
 func GetRelationEventPuljerByRoomIDAndPuljeID(db *sql.DB, roomID int, puljeID string) {

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -53,6 +53,60 @@ func CreateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
 	return &data, nil
 }
 
+// UpdateRoom updates a room based on its ID with new Room type data
+func UpdateRoom(db *sql.DB, data models.Room) (*models.Room, error) {
+	if strings.TrimSpace(data.RoomNumber) == "" {
+		return nil, fmt.Errorf("Room number is required")
+	}
+
+	// We can disable this check if we want, if so, remember to update test
+	if !strings.HasPrefix(data.RoomNumber, fmt.Sprintf("%d", data.Floor)) {
+		return nil, fmt.Errorf(
+			"Room number must start with the floor number, eg: %dxx, got: %s",
+			data.Floor,
+			data.RoomNumber,
+		)
+	}
+
+	if data.MaxConcurrentGames < 1 {
+		return nil, fmt.Errorf("Max concurrent events must be greater than 0, got: %d", data.MaxConcurrentGames)
+	}
+
+	query := `
+		UPDATE rooms
+		SET
+			name = ?,
+			room_number = ?,
+			floor = ?,
+			max_concurrent_games = ?,
+			notes = ?,
+			is_disabled = ?
+		WHERE id = ?
+		RETURNING
+			id,
+			name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled
+	`
+
+	var updated models.Room
+
+	err := db.QueryRow(
+		query, data.Name, data.RoomNumber, data.Floor, data.MaxConcurrentGames, data.Notes, data.IsDisabled, data.ID,
+	).Scan(
+		&updated.ID, &updated.Name, &updated.RoomNumber, &updated.Floor, &updated.MaxConcurrentGames, &updated.Notes, &updated.IsDisabled,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to update room: %w", err)
+	}
+
+	return &updated, nil
+}
+
 // UpdateRoom updates a room based on its ID with partial new information
 func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) {
 	if data.ID < 1 {

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -13,7 +13,7 @@ func CreateRoom(db *sql.DB, data models.Room)
 func UpdateRoom(db *sql.DB, data models.Room)
 
 // GetRoomByID returns a room pointer based on a roomID
-func GetRoomByID(db *sql.DB, roomID string)
+func GetRoomByID(db *sql.DB, roomID int)
 
 // GetAllRooms returns a list of all rooms stored in DB
 func GetAllRooms(db *sql.DB)
@@ -22,10 +22,18 @@ func GetAllRooms(db *sql.DB)
 func GetAllRoomStatusesByPuljeID(db *sql.DB, puljeID string) {
 	// This function needs to return a detailed overview of available rooms, where
 	// assigned events are limited to pulje
+
+	// Should this include complete events or just convert this to a number?
 }
 
-// SetRelationEventPuljeRoom assigns a room to an event in event_puljer_relation table
-func AssignRoomToRelationEventPuljer(db *sql.DB, roomID string, relationEventPuljeID string) {
-	// This function will assign a room by id to an event in event_puljer_relation
+// SetRelationEventPuljeRoom assigns a room to an event in `relation_event_puljer`
+func AssignRoomToRelationEventPuljer(db *sql.DB, roomID int, relationEventPuljeID string) {
+	// This function will assign a room by id to an event in relation_event_puljer
 	// Validate that the room does not exceed max events based on pulje?
+
+	// Move this function to event pujer as parent...
+}
+
+func GetRelationEventPuljerByRoomIDAndPuljeID(db *sql.DB, roomID int, puljeID string) {
+	// This functino will return all events assigned to a room limited by the pulje
 }

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -182,25 +182,9 @@ func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) 
 	// Construct args based on partial data
 	args = append(args, data.ID)
 
-	_, err := db.Exec(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to update room: %w", err)
-	}
-
+	// Update and return data
 	var updated models.Room
-
-	err = db.QueryRow(`
-		SELECT
-			id,
-			name,
-			room_number,
-			floor,
-			max_concurrent_games,
-			notes,
-			is_disabled
-		FROM rooms
-		WHERE id = ?
-	`, data.ID).Scan(
+	err := db.QueryRow(query, args...).Scan(
 		&updated.ID,
 		&updated.Name,
 		&updated.RoomNumber,

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -311,12 +311,13 @@ func GetAllRooms(db *sql.DB) ([]*models.Room, error) {
 	return rooms, nil
 }
 
-// GetAllRoomStatusesByPuljeID Generates a list of all rooms, but unique to a pulje
-func GetAllRoomStatusesByPuljeID(db *sql.DB, puljeID string) {
+// GetAllRoomStatusesByPulje Generates a list of all rooms, but unique to a pulje
+func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) ([]*models.RoomEventPuljeSummary, error) {
 	// This function needs to return a detailed overview of available rooms, where
 	// assigned events are limited to pulje
 
 	// Should this include complete events from event puljer, just event puljer id or just convert this to a number?
+	return nil, nil
 }
 
 // SetRelationEventPuljeRoom assigns a room to an event in `relation_event_puljer`

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -2,6 +2,7 @@ package rooms
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -217,7 +218,47 @@ func UpdateRoomPartial(db *sql.DB, data models.RoomInput) (*models.Room, error) 
 }
 
 // GetRoomByID returns a room pointer based on a roomID
-func GetRoomByID(db *sql.DB, roomID int) {}
+func GetRoomByID(db *sql.DB, roomID int) (*models.Room, error) {
+	if roomID < 1 {
+		return nil, fmt.Errorf("invalid room ID")
+	}
+
+	query := `
+		SELECT
+			id,
+			name,
+			room_number,
+			floor,
+			max_concurrent_games,
+			notes,
+			is_disabled
+		FROM rooms
+		WHERE id = ?
+	`
+
+	var room models.Room
+
+	err := db.QueryRow(query, roomID).Scan(
+		&room.ID,
+		&room.Name,
+		&room.RoomNumber,
+		&room.Floor,
+		&room.MaxConcurrentGames,
+		&room.Notes,
+		&room.IsDisabled,
+	)
+
+	if err != nil {
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("room with ID %d was not found", roomID)
+		}
+
+		return nil, fmt.Errorf("failed to get room with ID: %w", err)
+	}
+
+	return &room, nil
+}
 
 // GetAllRooms returns a list of all rooms stored in DB
 func GetAllRooms(db *sql.DB) {}

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -511,6 +511,58 @@ func TestGetAllRoomStatusesByPulje(t *testing.T) {
 	}
 }
 
+func TestAssignRoomToRelationEventPuljer(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services_assignment", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	// Seed databases with required data for relations
+	rooms := insertRooms(t, db)
+	puljer := insertPuljer(t, db)
+	events := insertEvents(t, db)
+
+	// Simplified relatinal insert
+	eventID := events[0]
+	puljeID := puljer[0]
+
+	_, err = db.Exec(`
+		INSERT INTO relation_event_puljer (event_id, pulje_id)
+		VALUES (?, ?)
+	`, eventID, puljeID)
+	if err != nil {
+		t.Fatalf("failed to insert relation: %v", err)
+	}
+
+	// When
+	result, err := AssignRoomToRelationEventPuljer(db, rooms[0], eventID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Thenn
+	if result.EventID != eventID {
+		t.Fatalf("Event ID did not match between input and ouptut\nexpected:\t%s\nrecieved:\t%s", eventID, result.EventID)
+	}
+	if result.PuljeID != models.Pulje(puljeID) {
+		t.Fatalf("Pulje ID did not match between input and ouptut\nexpected:\t%s\nrecieved:\t%s", models.Pulje(puljeID), result.PuljeID)
+	}
+
+	if !result.RoomID.Valid {
+		t.Fatalf("expected room_id to be set")
+	}
+
+	if result.RoomID.Int64 != int64(rooms[0]) {
+		t.Fatalf(
+			"Room number did not update\nexpected:\t%d\nrecieved:\t%d",
+			rooms[0],
+			result.RoomID.Int64,
+		)
+	}
+}
+
 func insertPuljer(t *testing.T, db *sql.DB) []string {
 	t.Helper()
 
@@ -546,7 +598,7 @@ func insertPuljer(t *testing.T, db *sql.DB) []string {
 	return ids
 }
 
-func insertRooms(t *testing.T, db *sql.DB) []int {
+func insertRooms(t *testing.T, db *sql.DB) []int64 {
 	t.Helper()
 
 	rooms := []models.Room{
@@ -604,9 +656,9 @@ func insertRooms(t *testing.T, db *sql.DB) []int {
             VALUES (?, ?, ?, ?, ?, ?)
             RETURNING id
         `
-	var roomIDs []int
+	var roomIDs []int64
 	for _, room := range rooms {
-		var roomID int
+		var roomID int64
 		err := db.QueryRow(query,
 			room.Name,
 			room.RoomNumber,

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -570,10 +570,10 @@ func insertPuljer(t *testing.T, db *sql.DB) []string {
         INSERT INTO puljer (
 			id, name, status, start_at, end_at
 		) VALUES
-			('Friday', 'Fredag kveld', 'published', '2025-10-03', '2025-10-03'),
-			('SaturdayMorning', 'Lørdag morgen', 'published', '2025-10-04', '2025-10-04'),
-			('SaturdayEvening', 'Lørdag kveld', 'published', '2025-10-04', '2025-10-04'),
-			('Sunday', 'Søndag morgen', 'published', '2025-10-05', '2025-10-05')
+			('Friday', 'Fredag kveld', 'Open', '2025-10-03', '2025-10-03'),
+			('SaturdayMorning', 'Lørdag morgen', 'Open', '2025-10-04', '2025-10-04'),
+			('SaturdayEvening', 'Lørdag kveld', 'Open', '2025-10-04', '2025-10-04'),
+			('Sunday', 'Søndag morgen', 'Open', '2025-10-05', '2025-10-05')
         RETURNING id
 	`
 	rows, err := db.Query(puljerQuery)

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -373,3 +373,29 @@ func TestGetAllRooms(t *testing.T) {
 		)
 	}
 }
+
+func TestGetAllRoomStatusesByPulje(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var expectedStatusesLength int = 2
+
+	// Populate db with rooms
+	// Populate db with events, puljer and some relation_event_pulje entries
+
+	// When
+	var pulje models.Pulje = models.PuljeFredagKveld
+	result, err := GetAllRoomStatusesByPulje(db, pulje)
+	if err != nil {
+		t.Fatalf("Unexpected arror: %v", err)
+	}
+
+	// Then
+	if len(result) != expectedStatusesLength {
+		t.Fatalf("Result of get all statuses did not match expected length\nexpected: %d\nrecieved: %d", expectedStatusesLength, len(result))
+	}
+}

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -74,6 +74,89 @@ func TestCreateRoom(t *testing.T) {
 	}
 }
 
+func TestUpdateRoom(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var originalRoom = models.Room{
+		Name:               "Hakkebakken",
+		RoomNumber:         "101",
+		Floor:              1,
+		MaxConcurrentGames: 2,
+		Notes:              "Dette er et gyldig rom",
+		IsDisabled:         false,
+	}
+
+	resultCreateRoom, err := CreateRoom(db, originalRoom)
+	if err != nil {
+		t.Fatalf("unexpected error creating original room: %v", err)
+	}
+
+	var updatedRoom = models.Room{
+		ID:                 resultCreateRoom.ID,
+		Name:               "Tangerud",
+		RoomNumber:         "209",
+		Floor:              2,
+		MaxConcurrentGames: 3,
+		Notes:              "Dette er en oppdatert note",
+		IsDisabled:         true,
+	}
+
+	var updatedRoomInvalidRoomNumber = *resultCreateRoom
+	updatedRoomInvalidRoomNumber.RoomNumber = ""
+
+	var updatedRoomInvalidRoomConcurrency = *resultCreateRoom
+	updatedRoomInvalidRoomConcurrency.MaxConcurrentGames = -1
+
+	var updatedRoomInvalidRoomNumberFloor = *resultCreateRoom
+	updatedRoomInvalidRoomNumberFloor.Floor = 3
+	updatedRoomInvalidRoomNumberFloor.RoomNumber = "203"
+
+	// When
+	resultUpdateRoomValid, err := UpdateRoom(db, updatedRoom)
+	if err != nil {
+		t.Fatalf("unexpected error when updating valid room: %v", err)
+	}
+
+	_, errInvalidRoomNumber := UpdateRoom(db, updatedRoomInvalidRoomNumber)
+	_, errInvalidRoomConcurrency := UpdateRoom(db, updatedRoomInvalidRoomConcurrency)
+	_, errInvalidRoomNumberFloor := UpdateRoom(db, updatedRoomInvalidRoomNumberFloor)
+
+	// Then
+	if resultCreateRoom.ID != resultUpdateRoomValid.ID {
+		t.Fatalf("UpdateRoom caused room ID to change\nexpected: \t%d\nrecieved: \t%d", resultCreateRoom.ID, resultUpdateRoomValid.ID)
+	}
+	if resultCreateRoom.Name == resultUpdateRoomValid.Name {
+		t.Fatalf("UpdateRoom did not update name correctly\nexpected: \t%s\nrecieved: \t%s", resultCreateRoom.Name, resultUpdateRoomValid.Name)
+	}
+	if resultCreateRoom.RoomNumber == resultUpdateRoomValid.RoomNumber {
+		t.Fatalf("UpdateRoom did not update room number correctly\nexpected: \t%s\nrecieved: \t%s", resultCreateRoom.RoomNumber, resultUpdateRoomValid.RoomNumber)
+	}
+	if resultCreateRoom.Floor == resultUpdateRoomValid.Floor {
+		t.Fatalf("UpdateRoom did not update floor number correctly\nexpected: \t%d\nrecieved: \t%d", resultCreateRoom.Floor, resultUpdateRoomValid.Floor)
+	}
+	if resultCreateRoom.Notes == resultUpdateRoomValid.Notes {
+		t.Fatalf("UpdateRoom did not update notes correctly\nexpected: \t%s\nrecieved: \t%s", resultCreateRoom.Notes, resultUpdateRoomValid.Notes)
+	}
+	if resultCreateRoom.MaxConcurrentGames == resultUpdateRoomValid.MaxConcurrentGames {
+		t.Fatalf("UpdateRoom did not update max concurrent games correctly\nexpected: \t%d\nrecieved: \t%d", resultCreateRoom.MaxConcurrentGames, resultUpdateRoomValid.MaxConcurrentGames)
+	}
+
+	if errInvalidRoomNumber == nil {
+		t.Fatalf("UpdateRoom allowed updating invalid room number")
+	}
+	if errInvalidRoomNumberFloor == nil {
+		t.Fatalf("UpdateRoom allowed updating with an invalid room number and floor combination")
+	}
+	if errInvalidRoomConcurrency == nil {
+		t.Fatalf("UpdateRoom allowed updating invalid max concurrent games")
+	}
+}
+
 func TestUpdateRoomPartial(t *testing.T) {
 	// Given
 	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
@@ -167,7 +250,3 @@ func TestUpdateRoomPartial(t *testing.T) {
 		t.Errorf("UpdateRoom allowed update when room number was an empty string")
 	}
 }
-
-func StringPtr(s string) *string { return &s }
-func IntPtr(i int) *int          { return &i }
-func BoolPtr(b bool) *bool       { return &b }

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -250,3 +250,51 @@ func TestUpdateRoomPartial(t *testing.T) {
 		t.Errorf("UpdateRoom allowed update when room number was an empty string")
 	}
 }
+
+func TestGetRoomByID(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var validRoom = models.Room{
+		Name:               "Hakkebakken",
+		RoomNumber:         "101",
+		Floor:              1,
+		MaxConcurrentGames: 2,
+		Notes:              "Dette er et gyldig rom",
+		IsDisabled:         false,
+	}
+
+	createdRoom, err := CreateRoom(db, validRoom)
+	if err != nil {
+		t.Fatalf("unexpected error creating room: %v", err)
+	}
+
+	// When
+	roomResult, err := GetRoomByID(db, createdRoom.ID)
+	if err != nil {
+		t.Fatalf("unexpected error getting room by ID: %v", err)
+	}
+
+	_, errInvalidID := GetRoomByID(db, 0)
+	_, errMissingRoom := GetRoomByID(db, -1)
+
+	// Then
+	if *roomResult != *createdRoom {
+		t.Fatalf(
+			"GetRoomByID did not return expected room\nexpected:\t%v\nrecieved:\t%v",
+			*createdRoom,
+			*roomResult,
+		)
+	}
+
+	if errInvalidID == nil {
+		t.Fatal("expected error when getting room with invalid ID, but it was allowed")
+	}
+	if errMissingRoom == nil {
+		t.Fatal("expected error when getting non-existing room, but it was allowed")
+	}
+}

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -298,3 +298,78 @@ func TestGetRoomByID(t *testing.T) {
 		t.Fatal("expected error when getting non-existing room, but it was allowed")
 	}
 }
+
+func TestGetAllRooms(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var validRooms = []models.Room{
+		{
+			Name:               "Hakkebakken",
+			RoomNumber:         "101",
+			Floor:              1,
+			MaxConcurrentGames: 2,
+			Notes:              "Room 1",
+			IsDisabled:         false,
+		}, {
+			Name:               "Tangerud",
+			RoomNumber:         "201",
+			Floor:              2,
+			MaxConcurrentGames: 4,
+			Notes:              "Second room",
+			IsDisabled:         false,
+		}, {
+			Name:               "Hundremeter Skogen",
+			RoomNumber:         "301",
+			Floor:              3,
+			MaxConcurrentGames: 1,
+			Notes:              "Second room",
+			IsDisabled:         false,
+		},
+	}
+
+	var createdRooms []models.Room
+	for _, room := range validRooms {
+		createdRoom, err := CreateRoom(db, room)
+		if err != nil {
+			t.Fatalf("unexpected error creating room: %v", err)
+		}
+
+		createdRooms = append(createdRooms, *createdRoom)
+	}
+
+	// When
+	resultRooms, err := GetAllRooms(db)
+	if err != nil {
+		t.Fatalf("unexpected error getting all rooms: %v", err)
+	}
+
+	// Then
+	// - ensure all rooms were returned
+	if len(resultRooms) != 3 {
+		t.Fatalf(
+			"expected 3 rooms, recieved: %d",
+			len(resultRooms),
+		)
+	}
+
+	// - ensure ordering is correct
+	if resultRooms[0].ID != createdRooms[0].ID {
+		t.Fatalf(
+			"expected first room ID %d, recieved %d",
+			createdRooms[0].ID,
+			resultRooms[0].ID,
+		)
+	}
+	if resultRooms[len(resultRooms)-1].ID != createdRooms[len(createdRooms)-1].ID {
+		t.Fatalf(
+			"expected last room ID %d, recieved %d",
+			createdRooms[len(createdRooms)-1].ID,
+			resultRooms[len(resultRooms)-1].ID,
+		)
+	}
+}

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -1,0 +1,75 @@
+package rooms
+
+import (
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func TestCreateRoom(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var validRoom = models.Room{
+		ID:                 0,
+		Name:               "Hakkebakken",
+		RoomNumber:         "101",
+		Floor:              1,
+		MaxConcurrentGames: 2,
+		Notes:              "Dette er et gyldig rom",
+		IsDisabled:         false,
+	}
+
+	var invalidRoomNumber = validRoom
+	invalidRoomNumber.Floor = 2
+
+	var invalidRoomConcurrency = validRoom
+	invalidRoomConcurrency.MaxConcurrentGames = -1
+
+	// When
+	// - create room is called once
+	createRoomResult, err := CreateRoom(db, validRoom)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// - create room is called again, tesing auto increment
+	createRoomResult2, err := CreateRoom(db, validRoom)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// - create room is called with an invalid room number based on the floor being its prefix
+	_, errInvalidRoomNumber := CreateRoom(db, invalidRoomNumber)
+
+	// - create room is called with an invalid room number based on the floor being its prefix
+	_, errInvalidConcurrency := CreateRoom(db, invalidRoomConcurrency)
+
+	// Then
+	if validRoom.ID == createRoomResult.ID {
+		t.Fatalf("Room ID did not update correctly after insert\nexpected: %d\nrecieved: %d", validRoom.ID, createRoomResult.ID)
+	}
+
+	validRoom.ID = createRoomResult.ID
+	if validRoom != *createRoomResult {
+		t.Fatalf("createRoomResult did not match happyRoom\nexpected: \t%v\nrecieved: \t%v", validRoom, createRoomResult)
+	}
+
+	var expectedID = createRoomResult.ID + 1
+	if createRoomResult2.ID != expectedID {
+		t.Fatalf("createRoom did not auto increment ID\nexpected: %d\nrecieved: %d", expectedID, createRoomResult2.ID)
+	}
+
+	if errInvalidRoomNumber == nil {
+		t.Fatal("expected error when creating room with invalid room number, but it was allowed")
+	}
+
+	if errInvalidConcurrency == nil {
+		t.Fatal("expected error when creating room with 0 or less max games, but it was allowed")
+	}
+}

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -1,6 +1,8 @@
 package rooms
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/Regncon/conorganizer/models"
@@ -376,26 +378,373 @@ func TestGetAllRooms(t *testing.T) {
 
 func TestGetAllRoomStatusesByPulje(t *testing.T) {
 	// Given
-	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services_event_puljer", t)
 	if err != nil {
 		t.Fatalf("failed to create test database and logger: %v", err)
 	}
 	defer db.Close()
 
-	var expectedStatusesLength int = 2
+	// Seed databases with required data for relations
+	rooms := insertRooms(t, db)
+	puljer := insertPuljer(t, db)
+	events := insertEvents(t, db)
 
-	// Populate db with rooms
-	// Populate db with events, puljer and some relation_event_pulje entries
+	query := `
+        INSERT INTO relation_event_puljer (
+            event_id,
+            pulje_id,
+            room_id
+        )
+        VALUES (?, ?, ?)
+        RETURNING
+            event_id,
+            pulje_id,
+            is_in_pulje,
+            is_published,
+            room_id
+    `
+
+	var eventPuljerSource = []models.EventPulje{
+		{
+			EventID: events[0],
+			PuljeID: models.Pulje(puljer[0]),
+			RoomID:  sql.NullInt64{Int64: int64(rooms[0]), Valid: true},
+		}, {
+			EventID: events[1],
+			PuljeID: models.Pulje(puljer[0]),
+			RoomID:  sql.NullInt64{Int64: int64(rooms[0]), Valid: true},
+		}, {
+			EventID: events[2],
+			PuljeID: models.Pulje(puljer[1]),
+			RoomID:  sql.NullInt64{Int64: int64(rooms[1]), Valid: true},
+		}, {
+			EventID: events[3],
+			PuljeID: models.Pulje(puljer[1]),
+			RoomID:  sql.NullInt64{Int64: int64(rooms[2]), Valid: true},
+		}, {
+			EventID: events[4],
+			PuljeID: models.Pulje(puljer[2]),
+			RoomID:  sql.NullInt64{Int64: int64(rooms[3]), Valid: true},
+		},
+	}
+
+	var createdEventPuljer []models.EventPulje
+	for _, eventSource := range eventPuljerSource {
+		var createdEvent models.EventPulje
+
+		err := db.QueryRow(
+			query,
+			eventSource.EventID,
+			eventSource.PuljeID,
+			eventSource.RoomID,
+		).Scan(
+			&createdEvent.EventID,
+			&createdEvent.PuljeID,
+			&createdEvent.IsInPulje,
+			&createdEvent.IsPublished,
+			&createdEvent.RoomID.Int64,
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to create event: %v", err)
+		}
+		createdEventPuljer = append(createdEventPuljer, createdEvent)
+	}
+
+	var expectedRoomStatuses = make(models.RoomStatusByPulje)
+	for _, createdEventPulje := range createdEventPuljer {
+		// Skipp events not added to a pulje or without a room assigned
+		if !createdEventPulje.IsInPulje && !createdEventPulje.RoomID.Valid {
+			continue
+		}
+
+		// Create pulje map if empty
+		puljeName := createdEventPulje.PuljeID
+		if expectedRoomStatuses[puljeName] == nil {
+			expectedRoomStatuses[puljeName] = make(map[int64]models.RoomByPulje)
+		}
+
+		// Create or update room
+		roomNumber := createdEventPulje.RoomID.Int64
+		room := expectedRoomStatuses[puljeName][roomNumber]
+
+		// Setup event array
+		if room.AssignedEventsID == nil {
+			room.AssignedEventsID = []models.RoomEventPuljeSummary{}
+		}
+
+		room.AssignedEventsID = append(room.AssignedEventsID, models.RoomEventPuljeSummary{
+			EventID: createdEventPulje.EventID,
+		})
+
+		expectedRoomStatuses[puljeName][roomNumber] = room
+	}
+
+	fmt.Print(expectedRoomStatuses)
 
 	// When
-	var pulje models.Pulje = models.PuljeFredagKveld
-	result, err := GetAllRoomStatusesByPulje(db, pulje)
+	resultPuljeFredag, err := GetAllRoomStatusesByPulje(db, models.PuljeFredagKveld)
 	if err != nil {
 		t.Fatalf("Unexpected arror: %v", err)
 	}
 
 	// Then
-	if len(result) != expectedStatusesLength {
+	fmt.Print(resultPuljeFredag)
+	/* if len(result) != expectedStatusesLength {
 		t.Fatalf("Result of get all statuses did not match expected length\nexpected: %d\nrecieved: %d", expectedStatusesLength, len(result))
+	} */
+}
+
+func insertPuljer(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+
+	puljerQuery := `
+        INSERT INTO puljer (
+			id, name, status, start_at, end_at
+		) VALUES
+			('P1', 'Friday', 'published', '2025-10-03', '2025-10-03'),
+			('P2', 'SaturdayMorning', 'published', '2025-10-04', '2025-10-04'),
+			('P3', 'SaturdayEvening', 'published', '2025-10-04', '2025-10-04'),
+			('P4', 'Sunday', 'published', '2025-10-05', '2025-10-05')
+        RETURNING name
+	`
+	rows, err := db.Query(puljerQuery)
+	if err != nil {
+		t.Fatalf("failed to insert puljer: %v", err)
 	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("failed to scan pulje id: %v", err)
+		}
+		names = append(names, name)
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration failed: %v", err)
+	}
+
+	return names
+}
+
+func insertRooms(t *testing.T, db *sql.DB) []int {
+	t.Helper()
+
+	rooms := []models.Room{
+		{
+			Name:               "Hundremeterskogen",
+			RoomNumber:         "101",
+			Floor:              1,
+			MaxConcurrentGames: 2,
+			Notes:              "Rom inspirert av skogen der Ole Brumm bor",
+			IsDisabled:         false,
+		},
+		{
+			Name:               "Brumms Hus",
+			RoomNumber:         "102",
+			Floor:              1,
+			MaxConcurrentGames: 3,
+			Notes:              "Koselig rom med plass til flere spill",
+			IsDisabled:         false,
+		},
+		{
+			Name:               "Tigerguttens Hjorne",
+			RoomNumber:         "201",
+			Floor:              2,
+			MaxConcurrentGames: 2,
+			Notes:              "Aktivt rom for mindre grupper",
+			IsDisabled:         false,
+		},
+		{
+			Name:               "Nasse Noffs Sti",
+			RoomNumber:         "202",
+			Floor:              2,
+			MaxConcurrentGames: 1,
+			Notes:              "Lite og stille rom",
+			IsDisabled:         false,
+		},
+		{
+			Name:               "Ugles Topp",
+			RoomNumber:         "301",
+			Floor:              3,
+			MaxConcurrentGames: 4,
+			Notes:              "Stort rom egnet for parallelle aktiviteter, men er inaktivt",
+			IsDisabled:         true,
+		},
+	}
+
+	query := `
+            INSERT INTO rooms (
+                name,
+                room_number,
+                floor,
+                max_concurrent_games,
+                notes,
+                is_disabled
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            RETURNING id
+        `
+	var roomIDs []int
+	for _, room := range rooms {
+		var roomID int
+		err := db.QueryRow(query,
+			room.Name,
+			room.RoomNumber,
+			room.Floor,
+			room.MaxConcurrentGames,
+			room.Notes,
+			room.IsDisabled,
+		).Scan(&roomID)
+		if err != nil {
+			t.Fatalf("Failed to create room: %v", err)
+		}
+		roomIDs = append(roomIDs, roomID)
+	}
+
+	return roomIDs
+}
+
+func insertEvents(t *testing.T, db *sql.DB) []string {
+	events := []models.Event{
+		{
+			Title:             "Mysteriet i Hundremeterskogen",
+			Intro:             "Et rolig mysterium for nye spillere.",
+			Description:       "Spillerne må finne ut hvorfor honningkrukkene til Ole Brumm forsvinner om natten.",
+			System:            "Call of Cthulhu",
+			EventType:         models.EventTypeBoardGame,
+			AgeGroup:          models.AgeGroupAdultsOnly,
+			Runtime:           models.RunTimeLongRunning,
+			HostName:          "Kristoffer",
+			Email:             "brumm@example.com",
+			PhoneNumber:       "90000001",
+			MaxPlayers:        5,
+			BeginnerFriendly:  true,
+			CanBeRunInEnglish: true,
+			Notes:             "Passer godt for førstegangsspillere",
+			Status:            "Publisert",
+		},
+		{
+			Title:             "Tigerguttens Turnering",
+			Intro:             "En energisk konkurranse med raske utfordringer.",
+			Description:       "Deltakerne konkurrerer i kreative oppgaver og samarbeid under press.",
+			System:            "Dungeons & Dragons 5e",
+			EventType:         models.EventTypeBoardGame,
+			AgeGroup:          models.AgeGroupAdultsOnly,
+			Runtime:           models.RunTimeLongRunning,
+			HostName:          "Ole",
+			Email:             "tiger@example.com",
+			PhoneNumber:       "90000002",
+			MaxPlayers:        6,
+			BeginnerFriendly:  true,
+			CanBeRunInEnglish: false,
+			Notes:             "",
+			Status:            "Kladd",
+		},
+		{
+			Title:             "Nasse Noffs Mørke Skog",
+			Intro:             "Et skrekkeventyr i dype skoger.",
+			Description:       "Noe beveger seg mellom trærne, og spillerne må overleve natten.",
+			System:            "Vaesen",
+			EventType:         models.EventTypeBoardGame,
+			AgeGroup:          models.AgeGroupAdultsOnly,
+			Runtime:           models.RunTimeLongRunning,
+			HostName:          "Anne",
+			Email:             "nasse@example.com",
+			PhoneNumber:       "90000003",
+			MaxPlayers:        4,
+			BeginnerFriendly:  false,
+			CanBeRunInEnglish: true,
+			Notes:             "Inneholder skrekkelementer",
+			Status:            "Publisert",
+		},
+		{
+			Title:             "Ugles Kunnskapsprove",
+			Intro:             "Quiz og strategi i kombinasjon.",
+			Description:       "Spillerne må samarbeide for å løse gåter og vinne over Ugle.",
+			System:            "Custom",
+			EventType:         models.EventTypeBoardGame,
+			AgeGroup:          models.AgeGroupAdultsOnly,
+			Runtime:           models.RunTimeLongRunning,
+			HostName:          "Mari",
+			Email:             "ugle@example.com",
+			PhoneNumber:       "90000004",
+			MaxPlayers:        8,
+			BeginnerFriendly:  true,
+			CanBeRunInEnglish: true,
+			Notes:             "",
+			Status:            "Publisert",
+		},
+		{
+			Title:             "Kengus Eventyrreise",
+			Intro:             "Et familievennlig fantasy-eventyr.",
+			Description:       "Bli med Kengu og Ro på en reise gjennom magiske landskap.",
+			System:            "Pathfinder 2e",
+			EventType:         models.EventTypeBoardGame,
+			AgeGroup:          models.AgeGroupAdultsOnly,
+			Runtime:           models.RunTimeLongRunning,
+			HostName:          "Sindre",
+			Email:             "kengu@example.com",
+			PhoneNumber:       "90000005",
+			MaxPlayers:        5,
+			BeginnerFriendly:  true,
+			CanBeRunInEnglish: false,
+			Notes:             "Familievennlig innhold",
+			Status:            "Godkjent",
+		},
+	}
+
+	query := `
+        INSERT INTO events (
+            title,
+            intro,
+            description,
+            system,
+            host_name,
+            user_id,
+            created_by_id,
+            updated_by_id,
+            email,
+            phone_number,
+            max_players,
+            age_group,
+            event_runtime,
+            beginner_friendly,
+            can_be_run_in_english,
+            status
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ) RETURNING id`
+
+	var eventIDs []string
+	for _, event := range events {
+		var eventID string
+		err := db.QueryRow(query,
+			event.Title,
+			event.Intro,
+			event.Description,
+			event.System,
+			event.HostName,
+			event.UserID,
+			event.CreatedByID,
+			event.UpdatedByID,
+			event.Email,
+			event.PhoneNumber,
+			event.MaxPlayers,
+			event.AgeGroup,
+			event.Runtime,
+			event.BeginnerFriendly,
+			event.CanBeRunInEnglish,
+			event.Status,
+		).Scan(&eventID)
+		if err != nil {
+			t.Fatalf("Failed to create event: %v", err)
+		}
+		eventIDs = append(eventIDs, eventID)
+	}
+
+	return eventIDs
 }

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -2,7 +2,6 @@ package rooms
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 
 	"github.com/Regncon/conorganizer/models"
@@ -424,7 +423,7 @@ func TestGetAllRoomStatusesByPulje(t *testing.T) {
 		}, {
 			EventID: events[4],
 			PuljeID: models.Pulje(puljer[2]),
-			RoomID:  sql.NullInt64{Int64: int64(rooms[3]), Valid: true},
+			RoomID:  sql.NullInt64{},
 		},
 	}
 
@@ -442,7 +441,7 @@ func TestGetAllRoomStatusesByPulje(t *testing.T) {
 			&createdEvent.PuljeID,
 			&createdEvent.IsInPulje,
 			&createdEvent.IsPublished,
-			&createdEvent.RoomID.Int64,
+			&createdEvent.RoomID,
 		)
 
 		if err != nil {
@@ -452,47 +451,64 @@ func TestGetAllRoomStatusesByPulje(t *testing.T) {
 	}
 
 	var expectedRoomStatuses = make(models.RoomStatusByPulje)
-	for _, createdEventPulje := range createdEventPuljer {
-		// Skipp events not added to a pulje or without a room assigned
-		if !createdEventPulje.IsInPulje && !createdEventPulje.RoomID.Valid {
+	for _, puljeID := range puljer {
+		pulje := models.Pulje(puljeID)
+
+		if expectedRoomStatuses[pulje] == nil {
+			expectedRoomStatuses[pulje] = make(map[int64]models.RoomByPulje)
+		}
+
+		for _, roomID := range rooms {
+			expectedRoomStatuses[pulje][int64(roomID)] = models.RoomByPulje{
+				ID:                 roomID,
+				Name:               "",
+				RoomNumber:         "",
+				MaxConcurrentGames: 0,
+				Notes:              "",
+				AssignedEventsID:   []models.RoomEventPuljeSummary{},
+			}
+		}
+	}
+	for _, eventPulje := range createdEventPuljer {
+		if !eventPulje.IsInPulje || !eventPulje.RoomID.Valid {
 			continue
 		}
 
-		// Create pulje map if empty
-		puljeName := createdEventPulje.PuljeID
-		if expectedRoomStatuses[puljeName] == nil {
-			expectedRoomStatuses[puljeName] = make(map[int64]models.RoomByPulje)
-		}
+		pulje := eventPulje.PuljeID
+		roomID := eventPulje.RoomID.Int64
 
-		// Create or update room
-		roomNumber := createdEventPulje.RoomID.Int64
-		room := expectedRoomStatuses[puljeName][roomNumber]
-
-		// Setup event array
-		if room.AssignedEventsID == nil {
-			room.AssignedEventsID = []models.RoomEventPuljeSummary{}
-		}
+		room := expectedRoomStatuses[pulje][roomID]
 
 		room.AssignedEventsID = append(room.AssignedEventsID, models.RoomEventPuljeSummary{
-			EventID: createdEventPulje.EventID,
+			EventID: eventPulje.EventID,
 		})
 
-		expectedRoomStatuses[puljeName][roomNumber] = room
+		expectedRoomStatuses[pulje][roomID] = room
 	}
 
-	fmt.Print(expectedRoomStatuses)
-
 	// When
-	resultPuljeFredag, err := GetAllRoomStatusesByPulje(db, models.PuljeFredagKveld)
+	result, err := GetAllRoomStatusesByPulje(db, models.PuljeFredagKveld)
 	if err != nil {
 		t.Fatalf("Unexpected arror: %v", err)
 	}
 
 	// Then
-	fmt.Print(resultPuljeFredag)
-	/* if len(result) != expectedStatusesLength {
-		t.Fatalf("Result of get all statuses did not match expected length\nexpected: %d\nrecieved: %d", expectedStatusesLength, len(result))
-	} */
+	for pulje, rooms := range expectedRoomStatuses {
+		for roomID, expectedRoom := range rooms {
+
+			actualRoom := result[pulje][roomID]
+
+			if len(actualRoom.AssignedEventsID) != len(expectedRoom.AssignedEventsID) {
+				t.Errorf(
+					"pulje=%s room=%d expected %d events, got %d",
+					pulje,
+					roomID,
+					len(expectedRoom.AssignedEventsID),
+					len(actualRoom.AssignedEventsID),
+				)
+			}
+		}
+	}
 }
 
 func insertPuljer(t *testing.T, db *sql.DB) []string {
@@ -502,11 +518,11 @@ func insertPuljer(t *testing.T, db *sql.DB) []string {
         INSERT INTO puljer (
 			id, name, status, start_at, end_at
 		) VALUES
-			('P1', 'Friday', 'published', '2025-10-03', '2025-10-03'),
-			('P2', 'SaturdayMorning', 'published', '2025-10-04', '2025-10-04'),
-			('P3', 'SaturdayEvening', 'published', '2025-10-04', '2025-10-04'),
-			('P4', 'Sunday', 'published', '2025-10-05', '2025-10-05')
-        RETURNING name
+			('Friday', 'Fredag kveld', 'published', '2025-10-03', '2025-10-03'),
+			('SaturdayMorning', 'Lørdag morgen', 'published', '2025-10-04', '2025-10-04'),
+			('SaturdayEvening', 'Lørdag kveld', 'published', '2025-10-04', '2025-10-04'),
+			('Sunday', 'Søndag morgen', 'published', '2025-10-05', '2025-10-05')
+        RETURNING id
 	`
 	rows, err := db.Query(puljerQuery)
 	if err != nil {
@@ -514,20 +530,20 @@ func insertPuljer(t *testing.T, db *sql.DB) []string {
 	}
 	defer rows.Close()
 
-	var names []string
+	var ids []string
 	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
+		var id string
+		if err := rows.Scan(&id); err != nil {
 			t.Fatalf("failed to scan pulje id: %v", err)
 		}
-		names = append(names, name)
+		ids = append(ids, id)
 	}
 
 	if err := rows.Err(); err != nil {
 		t.Fatalf("row iteration failed: %v", err)
 	}
 
-	return names
+	return ids
 }
 
 func insertRooms(t *testing.T, db *sql.DB) []int {

--- a/service/rooms/rooms_test.go
+++ b/service/rooms/rooms_test.go
@@ -29,7 +29,7 @@ func TestCreateRoom(t *testing.T) {
 	invalidRoomNumber.Floor = 2
 
 	var invalidRoomConcurrency = validRoom
-	invalidRoomConcurrency.MaxConcurrentGames = -1
+	invalidRoomConcurrency.MaxConcurrentGames = 0
 
 	// When
 	// - create room is called once
@@ -73,3 +73,101 @@ func TestCreateRoom(t *testing.T) {
 		t.Fatal("expected error when creating room with 0 or less max games, but it was allowed")
 	}
 }
+
+func TestUpdateRoomPartial(t *testing.T) {
+	// Given
+	db, _, err := testutil.CreateTemporaryDBAndLogger("test_room_services", t)
+	if err != nil {
+		t.Fatalf("failed to create test database and logger: %v", err)
+	}
+	defer db.Close()
+
+	var originalRoom = models.Room{
+		Name:               "Hakkebakken",
+		RoomNumber:         "101",
+		Floor:              1,
+		MaxConcurrentGames: 2,
+		Notes:              "Dette er et gyldig rom",
+		IsDisabled:         false,
+	}
+	var originalRoomPartial = models.Room{
+		Name:               "Hakkebakken",
+		RoomNumber:         "101",
+		Floor:              1,
+		MaxConcurrentGames: 2,
+		Notes:              "Dette er et gyldig rom",
+		IsDisabled:         false,
+	}
+
+	createRoomResult, err := CreateRoom(db, originalRoom)
+	if err != nil {
+		t.Fatalf("unexpected error creating original room: %v", err)
+	}
+	createRoomPartialResult, err := CreateRoom(db, originalRoomPartial)
+	if err != nil {
+		t.Fatalf("unexpected error creating original room: %v", err)
+	}
+
+	// When
+	var updatedName string = "Tangerud"
+	var updatedRoomNumber string = "303"
+	var updatedFloor int = 3
+	var updatedConcurrent int = 3
+	var updatedNotes string = ""
+	var updatedDisables bool = true
+
+	var updatedRoom = models.RoomInput{
+		ID:                 createRoomResult.ID,
+		Name:               &updatedName,
+		RoomNumber:         &updatedRoomNumber,
+		Floor:              &updatedFloor,
+		MaxConcurrentGames: &updatedConcurrent,
+		Notes:              &updatedNotes,
+		IsDisabled:         &updatedDisables,
+	}
+	updatedRoomResult, err := UpdateRoomPartial(db, updatedRoom)
+	if err != nil {
+		t.Fatalf("unexpected error when updating valid room: %v", err)
+	}
+	partialUpdatedRoomResult, err := UpdateRoomPartial(db, models.RoomInput{ID: createRoomPartialResult.ID, Name: &updatedName})
+	if err != nil {
+		t.Fatalf("unexpected error when partially updating valid room: %v", err)
+	}
+
+	var invalidRoomNumber string = ""
+	var invalidName string = ""
+	var invalidConcurrent int = -1
+
+	_, errInvalidID := UpdateRoomPartial(db, models.RoomInput{})
+	_, errInvalidName := UpdateRoomPartial(db, models.RoomInput{ID: 1, Name: &invalidName})
+	_, errInvalidRoomNumber := UpdateRoomPartial(db, models.RoomInput{ID: 1, RoomNumber: &invalidRoomNumber})
+	_, errInvalidConcurrency := UpdateRoomPartial(db, models.RoomInput{ID: 1, MaxConcurrentGames: &invalidConcurrent})
+
+	// Then
+	if originalRoom.Name != createRoomResult.Name {
+		t.Errorf("Original name was different to what create room returned")
+	}
+	if createRoomResult.Name == updatedRoomResult.Name {
+		t.Errorf("Room name persisted after updateRoom was called successfully\nexpected: \t%s\nrecieved: \t%s", createRoomResult.Name, updatedRoomResult.Name)
+	}
+	if createRoomPartialResult.Name == partialUpdatedRoomResult.Name {
+		t.Errorf("Room name persisted after updateRoom was called successfully\nexpected: \t%s\nrecieved: \t%s", createRoomPartialResult.Name, partialUpdatedRoomResult.Name)
+	}
+
+	if errInvalidID == nil {
+		t.Errorf("UpdateRoom allowed update when ID was omited")
+	}
+	if errInvalidName == nil {
+		t.Errorf("UpdateRoom allowed update when name was an empty string")
+	}
+	if errInvalidConcurrency == nil {
+		t.Errorf("UpdateRoom allowed update when max concurrent games was less than 1")
+	}
+	if errInvalidRoomNumber == nil {
+		t.Errorf("UpdateRoom allowed update when room number was an empty string")
+	}
+}
+
+func StringPtr(s string) *string { return &s }
+func IntPtr(i int) *int          { return &i }
+func BoolPtr(b bool) *bool       { return &b }

--- a/service/rooms/rooms_validation.go
+++ b/service/rooms/rooms_validation.go
@@ -3,10 +3,10 @@ package rooms
 import "database/sql"
 
 // ValidateRooms validates that all entries in `room` is valid
-func ValidateRooms(db *sql.DB)
+func ValidateRooms(db *sql.DB) {}
 
 // ValidateRoomsByPulje is used for validating that a snapshot of rooms, based on a pulje, is valid (eg. assigned vs max concurrent events per pulje)
-func ValidateRoomsByPulje(db *sql.DB, puljeID string)
+func ValidateRoomsByPulje(db *sql.DB, puljeID string) {}
 
 // ValidateDisabledRoomsCascade Validates that room disabled status has cascaded and no orphans exist in `relation_event_puljer`
-func ValidateDisabledRoomsCascade(db *sql.DB)
+func ValidateDisabledRoomsCascade(db *sql.DB) {}

--- a/service/rooms/rooms_validation.go
+++ b/service/rooms/rooms_validation.go
@@ -1,0 +1,12 @@
+package rooms
+
+import "database/sql"
+
+// ValidateRooms validates that all entries in `room` is valid
+func ValidateRooms(db *sql.DB)
+
+// ValidateRoomsByPulje is used for validating that a snapshot of rooms, based on a pulje, is valid (eg. assigned vs max concurrent events per pulje)
+func ValidateRoomsByPulje(db *sql.DB, puljeID string)
+
+// ValidateDisabledRoomsCascade Validates that room disabled status has cascaded and no orphans exist in `relation_event_puljer`
+func ValidateDisabledRoomsCascade(db *sql.DB)


### PR DESCRIPTION
## Kort oppsummering
Denne PR-en introduserer flere funksjoner i `/service` for håndtering av rom-funksjonalitet, slik som:
- Opprettelse av rom
- Henting av alle eller spesefikt rom
- Oppdatering av rom
- Status generering for romfordeling

I tillegg ligger alle modeller og hjelpe-funksjoner i `/models`
- `room` - et enkelt rom
- `RoomByPulje` - et enkelt rom, i en pulje, med tilhørende events for å se rom status
- `RoomStatusByPulje` - en aggrigert type som inneholder nødvendig data for generasjon av UI elementer

Alle funksjoner has medfølgende tester som har blitt bestått

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://373-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->