### PR TITLE
Add room pulje oversikt

### DIFF
--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -109,7 +109,7 @@ func updateEventPuljeMembershipWithAudit(ctx context.Context, db *sql.DB, logger
 	return nil
 }
 
-func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, roomID int64) error {
+func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, roomIDstring string) error {
 	updatedByID, err := currentUserDBID(ctx, db, logger)
 	if err != nil {
 		return err
@@ -121,10 +121,11 @@ func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, lo
 	}
 	defer tx.Rollback()
 
-	var roomIDValue sql.NullInt64
-	if roomID > 0 {
-		roomIDValue = sql.NullInt64{
-			Int64: roomID,
+	// convert roomID from string to sql.NullInt64
+	var roomID sql.NullInt64
+	if parsedRoomID, err := strconv.ParseInt(roomIDstring, 10, 64); err == nil {
+		roomID = sql.NullInt64{
+			Int64: parsedRoomID,
 			Valid: true,
 		}
 	}
@@ -135,7 +136,7 @@ func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, lo
 		WHERE event_id = ? AND pulje_id = ?
 	`
 
-	if _, err := tx.ExecContext(ctx, upsert, roomIDValue, eventID, puljeID); err != nil {
+	if _, err := tx.ExecContext(ctx, upsert, roomID, eventID, puljeID); err != nil {
 		return fmt.Errorf("upsert relation_event_puljer for event %q and pulje %q room %v: %w", eventID, puljeID, roomID, err)
 	}
 	if err := touchEventUpdatedAtWithUserID(ctx, tx, eventID, updatedByID); err != nil {

--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -370,7 +370,6 @@ templ FormBody(event *models.Event, isAdmin bool, db *sql.DB) {
 	if isAdmin {
 		@puljefordeling(event.ID, db)
 	}
-	<pre data-json-signals="{include: /room/}"></pre>
 	@contactInfo(
 		event.ID,
 		event.HostName,

--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -109,7 +109,7 @@ func updateEventPuljeMembershipWithAudit(ctx context.Context, db *sql.DB, logger
 	return nil
 }
 
-func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, roomIDstring string) error {
+func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, roomID int64) error {
 	updatedByID, err := currentUserDBID(ctx, db, logger)
 	if err != nil {
 		return err
@@ -121,23 +121,21 @@ func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, lo
 	}
 	defer tx.Rollback()
 
-	// convert roomID from string to sql.NullInt64
-	var roomID sql.NullInt64
-	if parsedRoomID, err := strconv.ParseInt(roomIDstring, 10, 64); err == nil {
-		roomID = sql.NullInt64{
-			Int64: parsedRoomID,
+	var roomIDValue sql.NullInt64
+	if roomID > 0 {
+		roomIDValue = sql.NullInt64{
+			Int64: roomID,
 			Valid: true,
 		}
 	}
 
-	// change
 	const upsert = `
 		UPDATE relation_event_puljer
 		SET room_id = ?
 		WHERE event_id = ? AND pulje_id = ?
 	`
 
-	if _, err := tx.ExecContext(ctx, upsert, roomID, eventID, puljeID); err != nil {
+	if _, err := tx.ExecContext(ctx, upsert, roomIDValue, eventID, puljeID); err != nil {
 		return fmt.Errorf("upsert relation_event_puljer for event %q and pulje %q room %v: %w", eventID, puljeID, roomID, err)
 	}
 	if err := touchEventUpdatedAtWithUserID(ctx, tx, eventID, updatedByID); err != nil {
@@ -371,6 +369,7 @@ templ FormBody(event *models.Event, isAdmin bool, db *sql.DB) {
 	if isAdmin {
 		@puljefordeling(event.ID, db)
 	}
+	<pre data-json-signals="{include: /room/}"></pre>
 	@contactInfo(
 		event.ID,
 		event.HostName,

--- a/components/formsubmission/puljefordeling.templ
+++ b/components/formsubmission/puljefordeling.templ
@@ -13,6 +13,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
+	"sort"
+	"strconv"
 )
 
 func UpdateIsPublished(eventRouter chi.Router, db *sql.DB, kv jetstream.KeyValue, logger *slog.Logger) {
@@ -141,9 +143,6 @@ func UpdateEventInPulje(eventRouter chi.Router, db *sql.DB, kv jetstream.KeyValu
 func UpdateRoomInPulje(roomRouter chi.Router, db *sql.DB, kv jetstream.KeyValue, logger *slog.Logger) {
 	roomRouter.Route("/{puljeId}", func(roomIdRouter chi.Router) {
 		roomIdRouter.Put("/", func(w http.ResponseWriter, r *http.Request) {
-			/* body, _ := io.ReadAll(r.Body)
-			fmt.Println("RAW BODY:", string(body)) */
-
 			eventID := chi.URLParam(r, "id")
 			if eventID == "" {
 				logger.Warn("Event ID is missing in the request")
@@ -160,7 +159,7 @@ func UpdateRoomInPulje(roomRouter chi.Router, db *sql.DB, kv jetstream.KeyValue,
 
 			// todo: convert this struct to nested json?
 			type Store struct {
-				RoomAssignment map[models.Pulje]int64 `json:"roomAssignment"`
+				RoomAssignment map[models.Pulje]string `json:"roomAssignment"`
 			}
 			store := &Store{}
 			if readSignalErr := datastar.ReadSignals(r, store); readSignalErr != nil {
@@ -171,13 +170,13 @@ func UpdateRoomInPulje(roomRouter chi.Router, db *sql.DB, kv jetstream.KeyValue,
 			roomID := store.RoomAssignment[models.Pulje(puljeId)]
 
 			if err := updateRoomInRelationEventPuljeWithAudit(r.Context(), db, logger, eventID, puljeId, roomID); err != nil {
-				logger.Error(fmt.Errorf("failed to upsert room %d in relation_event_puljer for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
+				logger.Error(fmt.Errorf("failed to upsert room %s in relation_event_puljer for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
 				http.Error(w, "Failed to update room in relation_event_puljer", http.StatusInternalServerError)
 				return
 			}
 
 			if err := keyvalue.BroadcastUpdate(kv, r); err != nil {
-				logger.Error(fmt.Errorf("failed to broadcast room %d update for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
+				logger.Error(fmt.Errorf("failed to broadcast room %s update for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
 				http.Error(w, "Failed to broadcast update", http.StatusInternalServerError)
 				return
 			}
@@ -217,6 +216,19 @@ func getEvenPulje(eventId string, pulje models.Pulje, db *sql.DB) (models.EventP
 		}
 	}
 	return event, nil
+}
+
+func RoomsFromMapSortedByNumber(m map[int64]models.RoomByPulje) []models.RoomByPulje {
+	rooms := make([]models.RoomByPulje, 0, len(m))
+	for _, r := range m {
+		rooms = append(rooms, r)
+	}
+
+	sort.Slice(rooms, func(i, j int) bool {
+		return rooms[i].RoomNumber < rooms[j].RoomNumber
+	})
+
+	return rooms
 }
 
 templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
@@ -265,12 +277,16 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 						class="checkbox input"
 					/>
 				</label>
+				{{
+					var assignedRoomNonNullable string = "0"
+					if eventPulje.RoomID.Valid {
+						assignedRoomNonNullable = strconv.FormatInt(eventPulje.RoomID.Int64, 10)
+					}
+				}}
 				<label
 					class="form-group"
 					style={ templ.KV("opacity: 0.5; border-color: gray;", !eventPulje.IsInPulje) }
-                    if eventPulje.RoomID.Valid {
-					    data-signals={ fmt.Sprintf("{roomAssignment:  {%s: %d}}", pulje.ID, eventPulje.RoomID.Int64) }
-                    }
+					data-signals={ fmt.Sprintf("{roomAssignment:  {%s: '%s'}}", pulje.ID, assignedRoomNonNullable) }
 				>
 					<span class="label-small color-strong">Legg til rom</span>
 					<select
@@ -281,13 +297,13 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 							disabled
 						}
 					>
-						<option value={ int64(0) }>Ikke tildelt</option>
-						for _,room := range roomStatus[pulje.ID] {
+						<option value="0">Ikke tildelt</option>
+						for _, room := range RoomsFromMapSortedByNumber(roomStatus[pulje.ID]) {
 							<option
-								value={ room.ID }
+								value={ fmt.Sprintf("%d", room.ID) }
 								style={ templ.KV("color: yellow;", room.IsFull()), templ.KV("color: red", room.CurrentOccupancy()>room.MaxConcurrentGames) }
 							>
-								#{ room.ID } { room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
+								#{ fmt.Sprintf("%d", room.ID) } { room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
 							</option>
 						}
 					</select>

--- a/components/formsubmission/puljefordeling.templ
+++ b/components/formsubmission/puljefordeling.templ
@@ -218,17 +218,40 @@ func getEvenPulje(eventId string, pulje models.Pulje, db *sql.DB) (models.EventP
 	return event, nil
 }
 
-func RoomsFromMapSortedByNumber(m map[int64]models.RoomByPulje) []models.RoomByPulje {
-	rooms := make([]models.RoomByPulje, 0, len(m))
-	for _, r := range m {
-		rooms = append(rooms, r)
+type FloorGroupPulje struct {
+	Floor int
+	Rooms []models.RoomByPulje
+}
+
+func getRoomsPuljeByFloor(db *sql.DB, pulje models.Pulje) []FloorGroupPulje {
+	var result []FloorGroupPulje
+	allRooms, err := rooms.GetAllRoomStatusesByPulje(db, pulje)
+	if err != nil {
+		return result
 	}
 
-	sort.Slice(rooms, func(i, j int) bool {
-		return rooms[i].RoomNumber < rooms[j].RoomNumber
+	allRoomsInPulje := allRooms[pulje]
+
+	floorMap := make(map[int][]models.RoomByPulje)
+	for _, room := range allRoomsInPulje {
+		floorMap[room.Floor] = append(floorMap[room.Floor], room)
+	}
+
+	for floor, rooms := range floorMap {
+		sort.Slice(rooms, func(i, j int) bool {
+			return rooms[i].RoomNumber < rooms[j].RoomNumber
+		})
+		result = append(result, FloorGroupPulje{
+			Floor: floor,
+			Rooms: rooms,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Floor > result[j].Floor
 	})
 
-	return rooms
+	return result
 }
 
 templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
@@ -237,10 +260,9 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 		<p>Error fetching event pulje: { err.Error() }</p>
 		return
 	}
-	{{ roomStatus, err := rooms.GetAllRoomStatusesByPulje(db, pulje.ID) }}
-	if err != nil {
-		<p>Error fetching rooms: { err.Error() }</p>
-		return
+	{{ roomStatus := getRoomsPuljeByFloor(db, pulje.ID) }}
+	if len(roomStatus) == 0 {
+		<p style="color: red;">Error fetching rooms</p>
 	}
 	<div style="display: flex; gap: 1rem; align-items: center;">
 		<div style="display: flex; gap: 0.5rem; flex-direction: column;">
@@ -298,13 +320,17 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 						}
 					>
 						<option value="0">Ikke tildelt</option>
-						for _, room := range RoomsFromMapSortedByNumber(roomStatus[pulje.ID]) {
-							<option
-								value={ fmt.Sprintf("%d", room.ID) }
-								style={ templ.KV("color: yellow;", room.IsFull()), templ.KV("color: red", room.CurrentOccupancy()>room.MaxConcurrentGames) }
-							>
-								#{ fmt.Sprintf("%d", room.ID) } { room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
-							</option>
+						for _, floor := range roomStatus {
+							<optgroup label={ fmt.Sprintf("%d. Etg", floor.Floor) }>
+								for _, room := range floor.Rooms {
+									<option
+										value={ fmt.Sprintf("%d", room.ID) }
+										style={ templ.KV("color: yellow;", room.IsFull()), templ.KV("color: red", room.CurrentOccupancy()>room.MaxConcurrentGames) }
+									>
+										{ room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
+									</option>
+								}
+							</optgroup>
 						}
 					</select>
 				</label>

--- a/components/formsubmission/puljefordeling.templ
+++ b/components/formsubmission/puljefordeling.templ
@@ -277,11 +277,12 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 					/>
 				</label>
 				<label
-					class="checkbox-background form-group-checkbox"
+					class="form-group"
 					style={ templ.KV("opacity: 0.5; border-color: gray;", !eventPulje.IsInPulje) }
 				>
-					<span>Legg til rom</span>
+					<span class="label-small color-strong">Legg til rom</span>
 					<select
+						class="input"
 						data-bind={ fmt.Sprintf("isInRoom%s", pulje.ID) }
 						data-on:change={ fmt.Sprintf("@put('/profile/api/new/%s/assign-room/%s', {contentType: 'json'})", eventId, pulje.ID) }
 						if !eventPulje.IsInPulje {
@@ -293,7 +294,7 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 							<option
 								value={ room.ID }
 								style={ templ.KV("color: yellow;", room.IsFull()), templ.KV("color: red", room.CurrentOccupancy()>room.MaxConcurrentGames) }
-								if eventPulje.RoomID.Valid && eventPulje.RoomID.Int64 == int64(room.ID) {
+								if eventPulje.RoomID.Valid && eventPulje.RoomID.Int64 == room.ID {
 									selected
 								}
 							>

--- a/components/formsubmission/puljefordeling.templ
+++ b/components/formsubmission/puljefordeling.templ
@@ -160,35 +160,24 @@ func UpdateRoomInPulje(roomRouter chi.Router, db *sql.DB, kv jetstream.KeyValue,
 
 			// todo: convert this struct to nested json?
 			type Store struct {
-				IsInRoomFredagKveld  string `json:"isInRoomFredagKveld"`
-				IsInRoomLordagMorgen string `json:"isInRoomLordagMorgen"`
-				IsInRoomLordagKveld  string `json:"isInRoomLordagKveld"`
-				IsInRoomSondagMorgen string `json:"isInRoomSondagMorgen"`
+				RoomAssignment map[models.Pulje]int64 `json:"roomAssignment"`
 			}
 			store := &Store{}
-
 			if readSignalErr := datastar.ReadSignals(r, store); readSignalErr != nil {
 				fmt.Println(readSignalErr.Error())
 				http.Error(w, readSignalErr.Error(), http.StatusBadRequest)
 			}
 
-			// Ugly hack to make data indexable
-			var inputByPulje = make(map[models.Pulje]string)
-			inputByPulje[models.PuljeFredagKveld] = store.IsInRoomFredagKveld
-			inputByPulje[models.PuljeLordagMorgen] = store.IsInRoomLordagMorgen
-			inputByPulje[models.PuljeLordagKveld] = store.IsInRoomLordagKveld
-			inputByPulje[models.PuljeSondagMorgen] = store.IsInRoomSondagMorgen
-
-			var roomID = inputByPulje[models.Pulje(puljeId)]
+			roomID := store.RoomAssignment[models.Pulje(puljeId)]
 
 			if err := updateRoomInRelationEventPuljeWithAudit(r.Context(), db, logger, eventID, puljeId, roomID); err != nil {
-				logger.Error(fmt.Errorf("failed to upsert room %s in relation_event_puljer for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
+				logger.Error(fmt.Errorf("failed to upsert room %d in relation_event_puljer for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
 				http.Error(w, "Failed to update room in relation_event_puljer", http.StatusInternalServerError)
 				return
 			}
 
 			if err := keyvalue.BroadcastUpdate(kv, r); err != nil {
-				logger.Error(fmt.Errorf("failed to broadcast room %s update for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
+				logger.Error(fmt.Errorf("failed to broadcast room %d update for event %s and pulje %s: %w", roomID, eventID, puljeId, err).Error())
 				http.Error(w, "Failed to broadcast update", http.StatusInternalServerError)
 				return
 			}
@@ -279,26 +268,26 @@ templ puljeRow(eventId string, pulje models.PuljeRow, db *sql.DB) {
 				<label
 					class="form-group"
 					style={ templ.KV("opacity: 0.5; border-color: gray;", !eventPulje.IsInPulje) }
+                    if eventPulje.RoomID.Valid {
+					    data-signals={ fmt.Sprintf("{roomAssignment:  {%s: %d}}", pulje.ID, eventPulje.RoomID.Int64) }
+                    }
 				>
 					<span class="label-small color-strong">Legg til rom</span>
 					<select
 						class="input"
-						data-bind={ fmt.Sprintf("isInRoom%s", pulje.ID) }
-						data-on:change={ fmt.Sprintf("@put('/profile/api/new/%s/assign-room/%s', {contentType: 'json'})", eventId, pulje.ID) }
+						data-bind={ fmt.Sprintf("roomAssignment.%s", pulje.ID) }
+						data-on:change={ fmt.Sprintf("@put('/profile/api/new/%s/assign-room/%s')", eventId, pulje.ID) }
 						if !eventPulje.IsInPulje {
 							disabled
 						}
 					>
-						<option value="lol git gud">Ikke tildelt</option>
+						<option value={ int64(0) }>Ikke tildelt</option>
 						for _,room := range roomStatus[pulje.ID] {
 							<option
 								value={ room.ID }
 								style={ templ.KV("color: yellow;", room.IsFull()), templ.KV("color: red", room.CurrentOccupancy()>room.MaxConcurrentGames) }
-								if eventPulje.RoomID.Valid && eventPulje.RoomID.Int64 == room.ID {
-									selected
-								}
 							>
-								{ room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
+								#{ room.ID } { room.RoomNumber } ({ room.CurrentOccupancy() }/{ room.MaxConcurrentGames })
 							</option>
 						}
 					</select>

--- a/models/rooms.go
+++ b/models/rooms.go
@@ -33,6 +33,13 @@ type RoomEventPuljeSummary struct {
 	EventPuljeID string
 	EventID      string
 	Title        string
+	MaxPlayers   string
+}
+type RoomEventPuljeSummaryJson struct {
+	EventPuljeID string `json:"pulje_id"`
+	EventID      string `json:"event_id"`
+	Title        string `json:"title"`
+	MaxPlayers   int    `json:"max_players"`
 }
 
 // RoomByPulje is a snapshot of room delegation for a specific pulje, this is mainly used for figuring
@@ -42,6 +49,7 @@ type RoomByPulje struct {
 	ID                 int64
 	Name               string
 	RoomNumber         string
+	Floor              int
 	AssignedEventsID   []RoomEventPuljeSummary
 	MaxConcurrentGames int
 	Notes              string
@@ -72,6 +80,7 @@ type RoomStatusRow struct {
 	RoomID             int64
 	RoomName           string
 	RoomNumber         string
+	Floor              int
 	MaxConcurrentGames int
 	RoomNotes          string
 

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -535,6 +535,7 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 					})
 				})
 			})
+
 			rooms.RoomsLayoutRoute(roomRouter, db, baseLogger, err)
 		})
 	})

--- a/pages/admin/rooms/room_page.templ
+++ b/pages/admin/rooms/room_page.templ
@@ -218,29 +218,23 @@ templ RoomsPageContent(db *sql.DB, logger *slog.Logger) {
         }
         }
 	</style>
-	<div class="page-content-container">
-		<h1 class="page-heading has-helptext">Administrer rom</h1>
-		<p class="page-heading-help-text">
-			Her kan du ligge til, endre og finne en oversikt over alle tilgjengelige rom
-		</p>
-		<button
-			type="button"
-			class="btn btn--outline"
-			data-on:click="
+	<button
+		type="button"
+		class="btn btn--outline"
+		data-on:click="
                 @get('/admin/rooms/api/create/');
                 document.getElementById('room-dialog').showModal()
             "
-		>Ligg til nytt rom</button>
-		@formModal()
-		<div class="rooms-layout">
-			{{ floors := getRoomsByFloor(db, logger) }}
-			if len(floors) > 0 {
-				for _, floorGroup := range floors {
-					@floorContainer(floorGroup.Floor, floorGroup.Rooms)
-				}
-			} else {
-				<p>No room data found, be the first to insert now!</p>
+	>Ligg til nytt rom</button>
+	@formModal()
+	<div class="rooms-layout">
+		{{ floors := getRoomsByFloor(db, logger) }}
+		if len(floors) > 0 {
+			for _, floorGroup := range floors {
+				@floorContainer(floorGroup.Floor, floorGroup.Rooms)
 			}
-		</div>
+		} else {
+			<p>No room data found, be the first to insert now!</p>
+		}
 	</div>
 }

--- a/pages/admin/rooms/rooms_by_pulje_page.templ
+++ b/pages/admin/rooms/rooms_by_pulje_page.templ
@@ -1,0 +1,21 @@
+package rooms
+
+import (
+	"database/sql"
+	"github.com/Regncon/conorganizer/models"
+	"log/slog"
+)
+
+templ RoomsByPuljePageContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+	<style>
+		.rooms-layout {
+			display: flex;
+			flex-direction: column;
+			gap: var(--responsive-page-section-spacing);
+            margin-top: var(--responsive-page-section-spacing);
+		}
+	</style>
+	<div class="rooms-layout">
+		<h2>test { pulje }</h2>
+	</div>
+}

--- a/pages/admin/rooms/rooms_by_pulje_page.templ
+++ b/pages/admin/rooms/rooms_by_pulje_page.templ
@@ -2,9 +2,128 @@ package rooms
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/Regncon/conorganizer/models"
+	roomService "github.com/Regncon/conorganizer/service/rooms"
 	"log/slog"
+	"sort"
 )
+
+type FloorGroupPulje struct {
+	Floor int
+	Rooms []models.RoomByPulje
+}
+
+func getRoomsPuljeByFloor(db *sql.DB, logger *slog.Logger, pulje models.Pulje) []FloorGroupPulje {
+	allRooms, err := roomService.GetAllRoomStatusesByPulje(db, pulje)
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to get rooms for pulje %s: %w", pulje, err).Error())
+	}
+
+	allRoomsInPulje := allRooms[pulje]
+
+	floorMap := make(map[int][]models.RoomByPulje)
+	for _, room := range allRoomsInPulje {
+		floorMap[room.Floor] = append(floorMap[room.Floor], room)
+	}
+
+	var result []FloorGroupPulje
+	for floor, rooms := range floorMap {
+		result = append(result, FloorGroupPulje{
+			Floor: floor,
+			Rooms: rooms,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Floor > result[j].Floor
+	})
+
+	return result
+}
+
+func getEventInPuljeWithoutRoom(db *sql.DB, logger *slog.Logger, pulje models.Pulje) []models.RoomEventPuljeSummaryJson {
+	query := `
+        SELECT
+            e.title,
+            e.max_players,
+            rep.event_id,
+            rep.pulje_id
+        FROM relation_event_puljer rep
+        JOIN events e ON e.id = rep.event_id
+        WHERE rep.pulje_id = ?
+        AND rep.is_in_pulje = 1
+        AND rep.room_id IS NULL;
+    `
+
+	rows, err := db.Query(query, pulje)
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to get events without room: %w", err).Error())
+		return nil
+	}
+	defer rows.Close()
+
+	var events []models.RoomEventPuljeSummaryJson
+	for rows.Next() {
+		var event models.RoomEventPuljeSummaryJson
+
+		err := rows.Scan(
+			&event.Title,
+			&event.MaxPlayers,
+			&event.EventID,
+			&event.EventPuljeID,
+		)
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to scan event: %w", err).Error())
+			continue
+		}
+
+		events = append(events, event)
+	}
+
+	fmt.Println(events, pulje)
+
+	if err := rows.Err(); err != nil {
+		logger.Error(fmt.Errorf("error iterating rows: %w", err).Error())
+	}
+
+	return events
+}
+
+templ roomPuljeContainer(room models.RoomByPulje) {
+	<div
+		class="room-container"
+	>
+		<h3>{ room.RoomNumber } </h3>
+		if room.Name == "" {
+			<p style="text-align:center; font-style: italic; color: gray;">Mangler romnavn</p>
+		} else {
+			<p style="text-align:center; font-style: italic;">{ room.Name }</p>
+		}
+		<hr/>
+		<div>
+			<h4>Tildelte spill: { len(room.AssignedEventsID) }/{ room.MaxConcurrentGames }</h4>
+			if len(room.AssignedEventsID) > 0 {
+				for _, event := range room.AssignedEventsID {
+					<p>{ event.Title }</p>
+				}
+			} else {
+				<p style="font-style: italic; color: gray;">Ingen tildelte spill</p>
+			}
+		</div>
+	</div>
+}
+
+templ floorPuljeContainer(floor int, rooms []models.RoomByPulje) {
+	<div class="floor-row">
+		<h2>{ floor }. Etg</h2>
+		<div class="floor-list">
+			for _, room := range rooms {
+				@roomPuljeContainer(room)
+			}
+		</div>
+	</div>
+}
 
 templ RoomsByPuljePageContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
 	<style>
@@ -14,8 +133,61 @@ templ RoomsByPuljePageContent(db *sql.DB, logger *slog.Logger, pulje models.Pulj
 			gap: var(--responsive-page-section-spacing);
             margin-top: var(--responsive-page-section-spacing);
 		}
+        .room-container {
+            display: flex;
+            flex-flow: column nowrap;
+            gap: var(--spacing-1x);
+            padding: var(--spacing-2x);
+            border: 1px solid var(--color-accent-blue);
+            border-radius: var(--border-radius-1x);
+            background-color: transparent;
+
+            h3 {
+                text-align: center;
+            }
+
+            p+p {
+                margin-top: auto;
+            }
+        }
+
+        .floor-row {
+            display: flex;
+            flex-flow: column nowrap;
+            gap: var(--spacing-2x)
+        }
+
+        .floor-list {
+            display: flex;
+            flex-flow: row wrap;
+            gap: var(--spacing-2x)
+        }
+        .event-list {
+            display: flex;
+            flex-flow: row wrap;
+            gap: var(--spacing-2x)
+        }
 	</style>
 	<div class="rooms-layout">
-		<h2>test { pulje }</h2>
+		<h2>Eventer i pulje uten tildelt rom</h2>
+		{{ events := getEventInPuljeWithoutRoom(db, logger, pulje) }}
+		if len(events) > 0 {
+			<div class="event-list">
+				for _, event := range events {
+					<a
+						role="button"
+						href={ "/admin/approval/edit/" + event.EventID }
+						class="btn btn--outline"
+					>{ event.Title } ({ event.MaxPlayers })</a>
+				}
+			</div>
+		}
+		<h2>Romfordelig for { pulje }</h2>
+		{{ floors := getRoomsPuljeByFloor(db, logger, pulje) }}
+		if len(floors) > 0 {
+			for _, floorGroup := range floors {
+				@floorPuljeContainer(floorGroup.Floor, floorGroup.Rooms)
+			}
+		}
 	</div>
 }

--- a/pages/admin/rooms/rooms_by_pulje_page.templ
+++ b/pages/admin/rooms/rooms_by_pulje_page.templ
@@ -29,6 +29,9 @@ func getRoomsPuljeByFloor(db *sql.DB, logger *slog.Logger, pulje models.Pulje) [
 
 	var result []FloorGroupPulje
 	for floor, rooms := range floorMap {
+		sort.Slice(rooms, func(i, j int) bool {
+			return rooms[i].RoomNumber < rooms[j].RoomNumber
+		})
 		result = append(result, FloorGroupPulje{
 			Floor: floor,
 			Rooms: rooms,
@@ -104,9 +107,11 @@ templ roomPuljeContainer(room models.RoomByPulje) {
 		<div>
 			<h4>Tildelte spill: { len(room.AssignedEventsID) }/{ room.MaxConcurrentGames }</h4>
 			if len(room.AssignedEventsID) > 0 {
-				for _, event := range room.AssignedEventsID {
-					<p>{ event.Title }</p>
-				}
+				<ul>
+					for _, event := range room.AssignedEventsID {
+						<li>{ event.Title }</li>
+					}
+				</ul>
 			} else {
 				<p style="font-style: italic; color: gray;">Ingen tildelte spill</p>
 			}

--- a/pages/admin/rooms/rooms_by_pulje_page.templ
+++ b/pages/admin/rooms/rooms_by_pulje_page.templ
@@ -131,6 +131,13 @@ templ floorPuljeContainer(floor int, rooms []models.RoomByPulje) {
 }
 
 templ RoomsByPuljePageContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+	<script>
+        window.addEventListener("pageshow", e => {
+            if (e.persisted) {
+                window.location.reload();
+            }
+        });
+    </script>
 	<style>
 		.rooms-layout {
 			display: flex;

--- a/pages/admin/rooms/rooms_index.templ
+++ b/pages/admin/rooms/rooms_index.templ
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Regncon/conorganizer/components"
 	"github.com/Regncon/conorganizer/layouts"
+	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/userctx"
 	"github.com/go-chi/chi/v5"
 	"log/slog"
@@ -13,24 +14,96 @@ import (
 
 func RoomsLayoutRoute(router chi.Router, db *sql.DB, logger *slog.Logger, err error) {
 	logger = logger.With("component", "rooms")
+
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		var ctx = r.Context()
 		userInfo := userctx.GetUserRequestInfo(r.Context())
 		if err := layouts.Base(
 			"Rom oversikt",
 			userInfo,
-			roomsIndex(db, logger),
+			roomsIndex(db, logger, RoomsPageContent(db, logger), "/"),
 		).Render(ctx, w); err != nil {
 			logger.Error(fmt.Errorf("failed to render rooms page: %w", err).Error(), "user_id", userInfo.Id)
 		}
 	})
+
+	router.Route("/{pulje}", func(roomByPuljeRouter chi.Router) {
+		roomByPuljeRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			var ctx = r.Context()
+			userInfo := userctx.GetUserRequestInfo(r.Context())
+
+			puljeQuery := chi.URLParam(r, "pulje")
+			if puljeQuery == "" {
+				http.Error(w, "Valid pulje is required. Got: "+puljeQuery, http.StatusBadRequest)
+				return
+			}
+
+			var pulje = models.Pulje(puljeQuery)
+
+			if err := layouts.Base(
+				"Rom oversikt",
+				userInfo,
+				roomsIndex(db, logger, RoomsByPuljePageContent(db, logger, models.Pulje(pulje)), pulje),
+			).Render(ctx, w); err != nil {
+				logger.Error(fmt.Errorf("failed to render rooms page: %w", err).Error(), "user_id", userInfo.Id)
+			}
+		})
+
+	})
 }
 
-templ roomsIndex(db *sql.DB, logger *slog.Logger) {
+templ roomsIndex(db *sql.DB, logger *slog.Logger, children templ.Component, puljeQuery models.Pulje) {
 	@components.Breadcrumbs([]components.BreadcrumbPath{
 		{Name: "Hjem", Url: "/"},
 		{Name: "Admin", Url: "/admin/"},
 		{Name: "Oversikt over rom", Url: ""},
 	})
-	@RoomsPageContent(db, logger)
+	<div class="page-content-container flex flex-col" style="gap: 1rem;">
+		<style>
+            .tabs {
+                display: flex;
+                gap: 0.5rem;
+                overflow-x: auto;
+                padding-bottom: 0.25rem;
+                border-bottom: 1px solid var(--color-accent-blue);
+            }
+
+            .tabs a {
+                white-space: nowrap;
+                text-decoration: none;
+                padding: 0.75rem 1rem;
+                border-radius: 8px;
+                color: var(--color-primary-text);
+                font-weight: 500;
+            }
+
+            .tabs a:hover {
+                color: var(--color-primary-hover);
+            }
+
+            .tabs a.active {
+                background: var(--primary);
+                color: var(--color-primary);
+            }
+            .tabs a.active a:hover {
+                background: var(--primary);
+                color: var(--color-primary-hover);
+            }
+        </style>
+		<h1 class="page-heading has-helptext" style="text-align: center;">Administrer rom</h1>
+		<p class="page-heading-help-text">
+			Her kan du ligge til, endre og finne en oversikt over alle tilgjengelige rom
+		</p>
+		<div class="tabs">
+			<a role="button" href="/admin/rooms/" class={ templ.KV("active", puljeQuery == "/") }>Rediger rom</a>
+			for _,pulje := range models.AllPuljer() {
+				<a
+					role="button"
+					href={ "/admin/rooms/" + pulje }
+					class={ templ.KV("active", puljeQuery == pulje) }
+				>{ pulje }</a>
+			}
+		</div>
+		@children
+	</div>
 }

--- a/service/rooms/rooms.go
+++ b/service/rooms/rooms.go
@@ -306,6 +306,7 @@ func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatu
             r.id,
             r.name,
             r.room_number,
+            r.floor,
             r.max_concurrent_games,
             r.notes,
 
@@ -344,6 +345,7 @@ func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatu
 			&row.RoomID,
 			&row.RoomName,
 			&row.RoomNumber,
+			&row.Floor,
 			&row.MaxConcurrentGames,
 			&row.RoomNotes,
 
@@ -366,6 +368,7 @@ func GetAllRoomStatusesByPulje(db *sql.DB, pulje models.Pulje) (models.RoomStatu
 				ID:                 row.RoomID,
 				Name:               row.RoomName,
 				RoomNumber:         row.RoomNumber,
+				Floor:              row.Floor,
 				MaxConcurrentGames: row.MaxConcurrentGames,
 				Notes:              row.RoomNotes,
 				AssignedEventsID:   []models.RoomEventPuljeSummary{},


### PR DESCRIPTION
# Summary
Added a dedicated page for viewing room statuses by `Pulje` which produces an overview of any rooms missing a room assignment and a complete list of rooms and their assigned events.
This PR also includes some updates to the room-assingment logic in puljefordeling for producing a more stable select element that doesn't have visual bugs.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://389-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->