### PR TITLE
Fix embedded NATS instability with an explicit JetStream StoreDir (#386)

### DIFF
--- a/.ai/threads/bug-no-live-update.md
+++ b/.ai/threads/bug-no-live-update.md
@@ -1,0 +1,362 @@
+--- Codex Session ---
+ID: 019e829f-7d0e-7191-bb69-088b6d4883b1
+
+# Bug live updates not starting
+
+There is a bug in the live updates. 
+I believe it affects all pages but I have only seen it on the admin page as that does not have the new initial page load yet and displays the error:
+`If you are seeing this message, please clear your cookies and refresh the page.` from the ` pages/admin/admin_index.templ` page.
+The `pages/admin/admin_page.templ` is supposed to load but it does not..
+You can find out more about the session from `pages/admin/admin.go`
+
+It has only been observed in production. 
+I suspect it happens when the nats session expires. 
+
+There is an error in the logs when I load the admin page that says:
+{"time":"2026-06-01T09:46:52.726785988Z","level":"ERROR","msg":"failed to stop admin watcher: nats: invalid subscription","component":"admin"}
+
+The reload functionality was initially based on the Northstar template https://github.com/zangster300/northstar
+I do not know if they still have the same code or if they have fixed it. You can check their repo for more info.
+
+We are not happy with the reload process as it is now. It is a little brittle and we want to make it more robust.
+
+Do research and see if you can find more information about this issue.
+
+Let's discuss this before we implement any fixes. If you have any clarifying questions just ask.
+
+
+Time: 2026-06-01 12:08:27
+--- Codex Run ---
+
+Codex output:
+I’ll trace the admin reload/session path locally, then compare it against the Northstar implementation and NATS subscription behavior. I’ll keep this to research and discussion only.
+The local pattern is a Datastar `data-init` GET to an SSE endpoint that patches the placeholder after the KV watcher receives an entry. One thing already stands out: the request context is passed into `kv.Watch`, and the deferred `watcher.Stop()` can be a second stop after cancellation, which would explain the `nats: invalid subscription` log as a cleanup symptom.
+Northstar’s current public README still describes the same family of template: Datastar plus embedded NATS KV for live updates. The current code layout has moved, so I’m checking both the public repo pages and Go module metadata for the actual route/watch implementation.
+There is another concrete fragility: several SSE handlers call `datastar.NewSSE` before `upsertSessionID`. Since `NewSSE` flushes headers immediately, a missing `connections` cookie cannot be reliably set from that SSE request. That makes the NATS/KV session identity weaker than it looks, especially after the cookie or KV entry expires.
+I researched this without changing code.
+
+**Current Read**
+
+Your NATS expiry suspicion looks plausible, but the specific log line is probably a cleanup symptom, not the primary failure:
+
+`failed to stop admin watcher: nats: invalid subscription`
+
+In the local NATS client code, `watcher.Stop()` ultimately calls `Unsubscribe()`. That returns `nats: invalid subscription` when the subscription is already closed. Since the request context is tied to the browser SSE connection, a refresh, disconnect, proxy close, or handler exit can close the watcher first. The deferred `watcher.Stop()` then logs an error during normal cleanup.
+
+So I would not treat that log as the root cause by itself.
+
+**More Likely Problem**
+
+I found a few brittle points that line up with the production behavior:
+
+1. Admin depends entirely on the live update request for first render  
+   [pages/admin/admin_index.templ](/home/cinmay/Documents/conorganizer/pages/admin/admin_index.templ:27) only renders the fallback message and calls:
+
+   `data-init="@get('/admin/api/',{requestCancellation: 'disabled'})"`
+
+   If `/admin/api/` fails, stalls, exits, or returns non-Datastar SSE, the admin page never replaces the placeholder. Other pages are less exposed because they already have newer initial server-rendered content.
+
+2. Admin creates the SSE response before session handling  
+   In [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:98), `datastar.NewSSE(w, r)` happens before `mvcSession(...)`.
+
+   The Datastar SSE helper flushes headers immediately. But `mvcSession` may call `sess.Save(r, w)` through `upsertSessionID`. Gorilla sessions expects saves before writing the response. If the `connections` cookie is missing, corrupt, expired, or needs rotation, the `Set-Cookie` can happen too late.
+
+   Profile does this in a safer order: session first, SSE second, and it also patches initial content directly. See [pages/profile/profile.go](/home/cinmay/Documents/conorganizer/pages/profile/profile.go:118).
+
+3. KV TTL is 1 hour, cookie session is 24 hours  
+   Admin creates the KV bucket with `TTL: time.Hour` in [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:42). The cookie store lifetime is 24h in [router.go](/home/cinmay/Documents/conorganizer/router.go:50).
+
+   That means the browser can retain a session id long after the NATS KV entry has expired.
+
+4. Watch handlers do not handle expiry/delete/purge events  
+   NATS KV expiry is represented as a delete/purge-style operation. The admin watcher loop treats every non-nil entry as JSON:
+
+   `json.Unmarshal(entry.Value(), mvc)`
+
+   If a TTL expiry event arrives with an empty value, that can produce `unexpected end of JSON input`, exit the SSE handler, and leave Datastar with no useful patch. This is especially bad on admin because there is no initial page content to fall back to.
+
+5. Production proxy behavior may amplify it  
+   The repo Caddy template is just a basic reverse proxy: [deploy/caddy-site.tmpl](/home/cinmay/Documents/conorganizer/deploy/caddy-site.tmpl:2). Caddy supports streaming reverse proxying, but if production has different timeout/compression/buffering config, an idle SSE connection could be closed. That would explain the cleanup log, though not necessarily the missing first render.
+
+**Northstar**
+
+I checked the public Northstar repo/package metadata. It is still a Go + Templ + Datastar + embedded NATS template, but I could not reliably fetch the exact current route source from this environment. Shell module download failed because network access from the sandbox is blocked. Public references:
+
+- https://github.com/zangster300/northstar
+- https://libraries.io/go/github.com%2Fzangster300%2Fnorthstar
+
+**Fix Direction I’d Prefer To Discuss**
+
+I would make live updates progressive enhancement instead of the boot path:
+
+1. Render `adminPage(db)` in the initial admin HTML, like the newer pages.
+2. Move session lookup/save before `datastar.NewSSE(...)` everywhere.
+3. Patch initial state immediately in `/admin/api/` before waiting on `kv.Watch`.
+4. Handle KV operations explicitly: ignore delete/purge, recreate missing session state, or force a clean reload.
+5. Stop logging `nats.ErrBadSubscription` as an error when request context is already done.
+6. Align the KV TTL and cookie lifetime, or refresh/touch the KV session while the SSE connection is alive.
+7. Consider Datastar reconnect behavior for long-lived streams, plus a heartbeat if production proxy idle timeouts are involved.
+
+**Questions**
+
+1. When the admin placeholder remains, what does browser devtools show for `/admin/api/`: status code, response headers, and whether it is pending, canceled, 401/403, 500, or 200 `text/event-stream`?
+2. Does this happen after roughly 60 minutes of an open page, or on a fresh load after being idle for more than an hour?
+3. Do production logs near that timestamp show JSON unmarshal errors, `failed to get key value`, auth failures, or HTTP status for `/admin/api/`?
+4. Does clearing only the `connections` cookie fix it, or do you need to clear auth cookies too?
+5. Is production Caddy exactly the repo template, or are there extra timeout/compression/buffering settings?
+
+Time: 2026-06-01 12:08:27
+--- Next Prompt ---
+
+Here is the response from the admin API on localhost, the site works fine. 
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+Date: Mon, 01 Jun 2026 11:25:41 GMT
+Transfer-Encoding: chunked
+
+
+Here is the response from the admin API on production, the site does not work.
+Request URL
+https://main.lekeplassen.regncon.no/admin
+Request Method
+GET
+Status Code
+200 OK
+Remote Address
+46.62.159.49:443
+Referrer Policy
+strict-origin-when-cross-origin
+content-type
+text/html; charset=utf-8
+
+date
+Mon, 01 Jun 2026 11:25:18 GMT
+via
+1.1 Caddy
+
+
+There is no cookie named `connections` in the production environment but there is one in the local environment.
+
+2. 60 minutes might be the case. 
+3. the only other error in the logs are:
+{"time":"2026-06-01T09:52:27.453245842Z","level":"ERROR","msg":"error running server: http: Server closed","component":"main"}
+4. There is no cookie named `connections` in the production environment when the issue occurs.
+5. Yes, caddy is exactly the repo template.
+
+Time: 2026-06-01 13:35:40
+--- Codex Run ---
+
+Codex output:
+That production request is for `/admin`, not `/admin/api/`, so the `text/html` response is expected for the shell page. The critical request is the Datastar-triggered `/admin/api/` stream; I’m going to re-check the route/template details against that symptom before giving you a tighter hypothesis.
+The missing `connections` cookie is a stronger clue than the watcher log. If `/admin/api/` is actually firing, that route is currently trying to create the cookie after the SSE headers are flushed, so production can end up with no cookie even though the handler ran.
+One thing in your headers stands out: the shell page is definitely being served, but we still do not know whether the module script and `data-init` path are executing in production. If `/admin/api/` is absent from the Network tab, this shifts from “SSE stream failed” to “Datastar never initialized.”
+That helps. The response you pasted is for `/admin`, not `/admin/api/`, so `text/html` is expected there. The API request we need to inspect is the Datastar request to:
+
+`/admin/api/`
+
+Healthy response should be `200` with `Content-Type: text/event-stream`.
+
+The missing `connections` cookie is now the main clue. In [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:98), admin does this:
+
+1. `datastar.NewSSE(w, r)`
+2. then `mvcSession(w, r)`
+3. then `upsertSessionID(...)`
+4. then `sess.Save(r, w)`
+
+But `NewSSE` flushes the headers immediately. Gorilla sessions explicitly expects `Save` before the response is written. So if production has no existing `connections` cookie, the handler may attempt to create one too late. That explains why production can stay without the cookie.
+
+This also explains why localhost can look fine: if localhost already has `connections`, the route does not need to successfully set it on that request.
+
+The `http: Server closed` log is not related to the page failure. That is normal shutdown being logged as an error.
+
+The remaining key unknown is whether `/admin/api/` is firing at all in production.
+
+Please check production DevTools with “Preserve log” enabled, refresh `/admin`, then filter Network for `admin/api`.
+
+I’d want these exact facts:
+
+1. Is there a `/admin/api/` request?
+2. If yes, what are its status and `Content-Type`?
+3. Does the response header include `Set-Cookie: connections=...`?
+4. Does `/static/datastar.js` load successfully, with no console module errors?
+5. If `/admin/api/` is pending, does its response body contain `event: datastar-patch-elements`?
+
+My current hypothesis is two-part:
+
+- First-load failure: `connections` cookie cannot be created reliably because SSE headers are flushed before session save.
+- 60-minute failure: the NATS KV value expires after 1 hour while the cookie lives for 24 hours, and the watcher code does not handle expiry/purge events robustly.
+
+For the fix discussion, I’d still lean toward making admin render real initial HTML first, then treating live updates as enhancement. That would remove this entire class of “placeholder forever” failures.
+
+Time: 2026-06-01 13:35:40
+--- Next Prompt ---
+
+
+The api output for locahost is:
+HTTP/1.1 200 OK
+Cache-Control: no-cache
+Content-Type: text/event-stream
+Date: Mon, 01 Jun 2026 11:36:38 GMT
+Templ-Skip-Modify: true
+Transfer-Encoding: chunked
+
+
+GET /admin/api/?datastar=%7B%7D HTTP/1.1
+Accept: text/event-stream, text/html, application/json
+Accept-Encoding: gzip, deflate, br, zstd
+Accept-Language: en-US,en;q=0.9,nb;q=0.8,no;q=0.7
+Cache-Control: no-cache
+Connection: keep-alive
+Content-Type: application/json
+Cookie: refresh_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IlNLMnVmenFmNDdIOVY2VFAzaktaZUFac05pUkFQIiwidHlwIjoiSldUIn0.eyJhbXIiOlsib2F1dGgiXSwiZHJuIjoiRFNSIiwiZHYiOjEsImVtYWlsIjoiY2lubWF5MDVAZ21haWwuY29tIiwiZXhwIjoxNzgxODgzNTgyLCJmdGkiOiJKM0U1TkhZUDlxc1h1MVNsVnpUZFVMdzE5WThNIiwiaWF0IjoxNzc5NDY0MzgyLCJpc3MiOiJQMnVmenFhaGxZVUhESXByVlh0a3VDeDhNSDVDIiwianRpIjoiSjNFNU5IWVA5cXNYdTFTbFZ6VGRVTHcxOVk4TSIsInN1YiI6IlUydWlPMmljMjNqMjZZU0F0VXNSd0pKQXZwbnkifQ.Kulh1kuDRuv1zKZqPdPkiUekW-BPfXKmOAnKd9KdweYMC9G7Fid2rRVPPc3fbdR-33sR4DC7cMXNzjGXkfIKE9h-wrjxHJWuf8fpo5q6S79DbWZG9mX83neN-b03SBlM9TSNObPV4RrOvYPCFHORc583oFfRXn4X1BTvqJM5OAqU8Rw-FP4uhdASyt7NfaclWqX-0ss99lyyGnf4Fenkb4Tp1_11eq-dC8zwiaWFVMcilHoeAyUvfD1zo4Ncybxg1DNWTr4D3PU0-BAs5BYR1gaVmmKpnaYToN8RNRZq7fx3qtdI3MXTArorCiORIMOiTtUpzkKVfACVVXx5uxqvpQ; connections=MTc4MDIzOTE3NXxEWDhFQVFMX2dBQUJFQUVRQUFCQV80QUFBUVp6ZEhKcGJtY01CQUFDYVdRR2MzUnlhVzVuRENZQUpESmhNR1U1WkdNM0xXUXhNR1l0TkROa015MWhNVGd6TFRSaFltSm1OR1UyWW1NM05nPT18TY5-BYGFO5oa1fr8iNTpMUWLdMwX56G9ht_6tNLUlPs=; session_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IlNLMnVmenFmNDdIOVY2VFAzaktaZUFac05pUkFQIiwidHlwIjoiSldUIn0.eyJhbXIiOlsib2F1dGgiXSwiZHJuIjoiRFMiLCJlbWFpbCI6ImNpbm1heTA1QGdtYWlsLmNvbSIsImV4cCI6MTc4MDMxNDM5NSwiaWF0IjoxNzgwMzEzNzk1LCJpc3MiOiJQMnVmenFhaGxZVUhESXByVlh0a3VDeDhNSDVDIiwicmV4cCI6IjIwMjYtMDYtMjlUMTE6MzY6MzVaIiwicm9sZXMiOlsiQWRtaW4iXSwic3ViIjoiVTJ1aU8yaWMyM2oyNllTQXRVc1J3SkpBdnBueSJ9.pbYuNAzUA2vlmYs7k0uJkH6ZBgTbejk7BsUKTOivVSBCv4HMXr-hclgfxso66PXDipkBMpk8y_fQ9HUGorFUY1QetIWdc9q_AjgJ1RmF2kfil87cotT0AAHDMWe_QJZe2ktHz7SLPCB9WSlNMPXwX-DEttt4_dDBs69QY-9wxayE2XzekB1CcqHABL-R6ue7WLz3zMOR3ICAfyp6_JxtqYtHCiXAMp7eKzvBzUWDOTJ4JT-SOsvYlMF94RdCvUm13bBota2eb-H8VNkPTDfI78C3y9eqy3sxZL9HL9mCrrD7Whl7vI7i1UBUPdtj1eMUSPqcsCUSP27P_FRfSxNBCA
+Datastar-Request: true
+Host: localhost:7331
+Pragma: no-cache
+Referer: http://localhost:7331/admin
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: same-origin
+User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36
+sec-ch-ua: "Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"
+sec-ch-ua-mobile: ?0
+sec-ch-ua-platform: "Linux"
+
+
+The production environment output is:
+
+Request URL
+https://main.lekeplassen.regncon.no/admin/api/?datastar=%7B%7D
+Request Method
+GET
+Status Code
+200 OK
+Remote Address
+46.62.159.49:443
+Referrer Policy
+strict-origin-when-cross-origin
+
+cache-control
+no-cache
+content-type
+text/event-stream
+date
+Mon, 01 Jun 2026 11:37:11 GMT
+via
+1.1 Caddy
+:authority
+main.lekeplassen.regncon.no
+:method
+GET
+:path
+/admin/api/?datastar=%7B%7D
+:scheme
+https
+accept
+text/event-stream, text/html, application/json
+accept-encoding
+gzip, deflate, br, zstd
+accept-language
+en-US,en;q=0.9,nb;q=0.8,no;q=0.7
+cache-control
+no-cache
+content-type
+application/json
+cookie
+refresh_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IlNLMnVmenFmNDdIOVY2VFAzaktaZUFac05pUkFQIiwidHlwIjoiSldUIn0.eyJhbXIiOlsib2F1dGgiXSwiZHJuIjoiRFNSIiwiZHYiOjEsImVtYWlsIjoiY2lubWF5MDVAZ21haWwuY29tIiwiZXhwIjoxNzgyNjU3NTU0LCJmdGkiOiJKM0VVZzJVNDd1OFRvbGhNYVU3MHR5SmV1b3ZoIiwiaWF0IjoxNzgwMjM4MzU0LCJpc3MiOiJQMnVmenFhaGxZVUhESXByVlh0a3VDeDhNSDVDIiwianRpIjoiSjNFVWcyVTQ3dThUb2xoTWFVNzB0eUpldW92aCIsInN1YiI6IlUydWlPMmljMjNqMjZZU0F0VXNSd0pKQXZwbnkifQ.QGuok7vzEy4zGvoXFbbfYWAe0wnVN8DdHS40qkAtgMBoSWi2WoHNjk36gp2vDgs-Z61MSOqqo6jcsn0IC2aUs3HobUXp655SKqNoA4_UCotiB4e5w8X-6F4-DkZS-qN0bXnIoQJahznrmshRcDd1BTwZLig_QuqacfYYTwCzrZuSogVcFLsT0-z0RaaGmgGJbIOiKQTR9RflmzSnJr54FEbGUxekQvvhisFQfk4AA9bAKQfoJ6APIdyzBpTeBEqSIYI2izkLpeGJzM24xy62Mi571rc52HYHWIzDhKXCazJ4UYl2APb0VrSdnEJpS1PEYOYWm84KlE55KhhMQ73hjw; session_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IlNLMnVmenFmNDdIOVY2VFAzaktaZUFac05pUkFQIiwidHlwIjoiSldUIn0.eyJhbXIiOlsib2F1dGgiXSwiZHJuIjoiRFMiLCJlbWFpbCI6ImNpbm1heTA1QGdtYWlsLmNvbSIsImV4cCI6MTc4MDMxNDQyOCwiaWF0IjoxNzgwMzEzODI4LCJpc3MiOiJQMnVmenFhaGxZVUhESXByVlh0a3VDeDhNSDVDIiwicmV4cCI6IjIwMjYtMDYtMjlUMTE6Mzc6MDhaIiwicm9sZXMiOlsiQWRtaW4iXSwic3ViIjoiVTJ1aU8yaWMyM2oyNllTQXRVc1J3SkpBdnBueSJ9.t5txr0PB3xFMdsC8p3oBstF5z9nxuf8hlxsiQir34HzXlnEhDd0QxZVTfVrvif45l_rAXJtt89rbn7oJ_z3aerzdaCzfcdabFPISFwgfTfd7ow9LcgfJag4HGja4mm2cJIZxZ-mchBwz95YU9kExPkqMu8Qd6oKN-w0Sya4gQd9rzQW9W6_-Wd3qxwbUIE6j1-HFBlq9-pLVVqriEi1ErDmbC8Fq1-tgr2n8vxA0sWq-PjmKO_IcKKnLXAuGo1yeS25YDnH6qVQ0q8Av3kqDrFiQrIgeTDwkYVa63rHsUx1-3JTorhXP2TLMK9LD6F9xOA3TnDT-sgIqW_QzVzpXtg
+datastar-request
+true
+pragma
+no-cache
+priority
+u=1, i
+referer
+https://main.lekeplassen.regncon.no/admin
+sec-ch-ua
+"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"
+sec-ch-ua-mobile
+?0
+sec-ch-ua-platform
+"Linux"
+sec-fetch-dest
+empty
+sec-fetch-mode
+cors
+sec-fetch-site
+same-origin
+user-agent
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36
+
+Time: 2026-06-01 13:41:09
+--- Codex Run ---
+
+Codex output:
+This is useful: production is reaching the SSE route and getting `text/event-stream`, but the request has no `connections` cookie and the response headers you pasted do not show a `Set-Cookie`. That strongly confirms the session cookie write is happening too late in the admin SSE handler.
+This narrows it down a lot.
+
+Production is reaching `/admin/api/`, Datastar is running, Caddy is not blocking the stream, and auth is passing. The broken part is now inside the SSE handler.
+
+The key difference is this:
+
+- localhost request includes `connections=...`
+- production request does not
+- production response does not show `Set-Cookie: connections=...`
+
+Given [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:98), that is expected: `datastar.NewSSE(w, r)` flushes headers before `upsertSessionID` can save the cookie. So production cannot establish the live-update session cookie from this route.
+
+There is still one thing to confirm: whether the production SSE response body ever receives a patch event.
+
+Please check the `/admin/api/` **Response** tab:
+
+- If it is empty/pending forever, the server opened SSE but never emitted the initial `adminPage` patch.
+- If it contains `event: datastar-patch-elements`, then the server emitted a patch and the issue is client-side patch application.
+- If it closes quickly, then the handler is probably exiting on an unlogged error.
+
+Right now my strongest hypothesis is:
+
+1. Production has no `connections` cookie.
+2. Admin creates a new session id but cannot send the cookie because SSE already flushed headers.
+3. Admin then relies on `kv.Watch(...)` to emit the initial page patch.
+4. In the no-cookie/new-session case, that initial patch is not reliably emitted, or the stream exits before it reaches the client.
+5. Because admin has no real initial HTML, the fallback message remains forever.
+
+The fastest local reproduction test would be: delete only the `connections` cookie on localhost, refresh `/admin`, and see whether it behaves like production. If it does, we have the bug boxed in.
+
+I also noticed the current admin handler does not log the important failures in this path. For example, `mvcSession` errors, `kv.Watch` errors, and `json.Unmarshal` errors are written with `http.Error` after SSE has started, but not logged. So the absence of logs does not rule out a server-side failure.
+
+Time: 2026-06-01 13:41:09
+--- Next Prompt ---
+I have to wait for the bug to occur in production again.
+Perhaps we can add the missing logging in the meantime so that we have more info when it happens again?
+
+Time: 2026-06-01 13:49:15
+--- Codex Run ---
+
+Codex output:
+I’ll add targeted logging around the admin SSE lifecycle and error paths, using the repo’s slog conventions, so the next production occurrence tells us whether the stream never patches, exits on KV/session/unmarshal, or only fails cleanup.
+Using the `conorganizer-logging` skill for this pass. I’m keeping it scoped to the admin live-update route first, since that is the observed failure path and we do not want noisy logs across every stream yet.
+The edit I’m about to make adds debug-level lifecycle breadcrumbs plus error logs where the handler currently writes to the SSE response and returns silently. I’ll avoid logging cookies, tokens, or the generated session id; only booleans, request id, watcher operation, revision, and value length.
+The admin stream now logs start, watcher start, initial marker, patch sent, channel close, and the previously silent session/watch/unmarshal/patch failures. I also downgraded the already-closed NATS subscription cleanup case to debug so it stops hiding the useful error signal.
+The broad admin package test hit two environment/pre-existing problems: Go’s default build cache is outside the writable sandbox, and `pages/admin/rooms` currently does not build because generated code references `RoomsPageContent`. I’m rerunning the directly touched package with `GOCACHE` under `/tmp` to separate our change from that.
+One adjustment: production defaults to `LOG_LEVEL=INFO`, so pure debug breadcrumbs would not show unless you temporarily raise the level. I’m making the two suspicious states visible at warn level: missing `connections` cookie on the admin stream, and “watcher delivered initial marker before any patch.”
+Added targeted admin live-update logging in [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:101).
+
+What it will now capture:
+
+- `WARN` when `/admin/api/` starts without a `connections` cookie.
+- `WARN` when the NATS watcher reports “initial values delivered” before any admin page patch was sent.
+- `ERROR` for previously silent session, watcher creation, JSON unmarshal, and Datastar patch failures.
+- `DEBUG` lifecycle logs for stream start, watcher start, normal close, patch sent, and already-stopped watcher cleanup.
+- The noisy `nats: invalid subscription` cleanup case is now debug-level when it happens after context close or an already-closed subscription.
+
+I avoided logging tokens, cookies, or the generated session id. The useful correlation fields are `request_id`, `connections_cookie_present`, `operation`, `revision`, and `value_bytes`.
+
+Validation:
+- Ran `gofmt`.
+- Ran `git diff --check`.
+- `GOCACHE=/tmp/conorganizer-go-build go test ./pages/admin` is currently blocked by an existing generated-code issue: `pages/admin/rooms/rooms_index_templ.go:66:24: undefined: RoomsPageContent`.
+
+For the next production occurrence, default `LOG_LEVEL=INFO` should show the new `WARN`/`ERROR` records. Set `LOG_LEVEL=DEBUG` if you want the full stream lifecycle.
+
+Time: 2026-06-01 13:49:15
+--- Next Prompt ---
+

--- a/.ai/threads/bug-no-live-update.md
+++ b/.ai/threads/bug-no-live-update.md
@@ -359,4 +359,309 @@ For the next production occurrence, default `LOG_LEVEL=INFO` should show the new
 
 Time: 2026-06-01 13:49:15
 --- Next Prompt ---
+Is there a way we can reproduce the issue locally without waiting for it to happen in production again? For example, can we add a button to flush all the NATS KV entries? Or reduce the TTL to 1 minute and wait for it to expire?
+
+Time: 2026-06-02 07:54:33
+--- Codex Run ---
+
+Codex output:
+Yes. I’d use two repro paths, in this order:
+
+1. **No-code repro first**
+   Delete only the `connections` cookie on localhost, then refresh `/admin`.
+
+   That directly simulates the production state you observed: authenticated user, but no live-update session cookie. If this reproduces the placeholder, we already have a tight local case.
+
+2. **Add a local-only debug purge**
+   I would not add a visible production admin button. Safer option: add a debug-only admin endpoint, enabled by an env var, for example:
+
+   `CONORGANIZER_DEBUG_LIVE_UPDATES=true`
+
+   Then expose something like:
+
+   `POST /admin/debug/live-updates/purge`
+
+   It would purge keys from the relevant NATS KV bucket. That should simulate TTL expiry immediately while the SSE watcher is active. With the logging we just added, we should see whether the watcher receives a purge/delete event, whether `value_bytes=0`, and whether JSON unmarshal kills the stream.
+
+3. **Optional TTL knob**
+   Add an env-controlled KV TTL, defaulting to `1h`:
+
+   `CONORGANIZER_LIVE_UPDATE_TTL=1m`
+
+   This is useful, but a bit more invasive because the `"events"` bucket is created from several route setup functions. We’d want a shared helper/config value so root/admin/event/profile do not fight over bucket TTL.
+
+My recommendation: first try deleting `connections` locally. If that does not reproduce, add the debug-only purge endpoint. TTL reduction is useful after that, but less direct than purging while watching the stream.
+
+Time: 2026-06-02 07:54:33
+--- Next Prompt ---
+Deleting the `connections` cookie locally and refreshing did nothing. 
+Go ahead and add the debug-only purge endpoint and show me the cli command to call it.
+
+Time: 2026-06-02 07:59:45
+--- Codex Run ---
+
+Codex output:
+I’ll implement this as an admin-authenticated debug endpoint gated by an env var, not a normal UI button. That gives us a local reproduction tool without putting a destructive control into the production admin page by accident.
+The endpoint will purge the existing keys from the `events` KV bucket and leave the purge markers in place, which is what we want for reproducing the watcher behavior. Open `/admin` first, then call the endpoint while the SSE stream is active.
+I’ve added the route registration under the admin router and it only exists when the debug env var is enabled. Now I’m adding the small helper that lists and purges the KV keys without logging the session keys themselves.
+I spotted and cleaned up a clumsy loop shape in the helper before formatting and validation.
+The endpoint is now implemented. I’m formatting and then running the same targeted test; I expect the existing `rooms` generated-code failure may still block the package build.
+The directly touched package now builds with the writable Go cache. I’m also checking the broader admin subtree so I can report whether the earlier generated-code failure is still present.
+`git diff --check` is blocked by a trailing whitespace issue in `.ai/threads/bug-no-live-update.md`, which I did not edit. I’m leaving that file alone and waiting for the broader admin tests to finish.
+The full admin subtree tests pass with the writable Go cache. I’m running whitespace validation only on the file I changed because the thread note has pre-existing trailing whitespace.
+Implemented the debug-only purge endpoint in [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:103).
+
+It is only mounted when this env var is enabled:
+
+```sh
+CONORGANIZER_DEBUG_LIVE_UPDATES=true
+```
+
+Start locally with it enabled:
+
+```sh
+CONORGANIZER_DEBUG_LIVE_UPDATES=true go tool task start
+```
+
+Then open `/admin` in the browser first so the SSE watcher is active. Call the purge endpoint with your local auth cookies:
+
+```sh
+COOKIE='session_token=...; refresh_token=...; connections=...'
+
+curl -i -X POST 'http://localhost:7331/admin/debug/live-updates/purge' \
+  -H "Cookie: $COOKIE"
+```
+
+Expected response:
+
+```json
+{"bucket":"events","purged":1}
+```
+
+If `purged` is `0`, refresh `/admin` once, keep it open, and run the curl again.
+
+The endpoint purges keys from the `events` KV bucket and leaves the purge markers, which should exercise the same watcher path as TTL expiry. It logs `purged_count` but does not log the session keys.
+
+Validation:
+- `GOCACHE=/tmp/conorganizer-go-build go test ./pages/admin/...` passed.
+- `git diff --check -- pages/admin/admin.go` passed.
+
+Note: `.ai/threads/bug-no-live-update.md` is modified in the worktree and has trailing whitespace; I left it untouched.
+
+Time: 2026-06-02 07:59:45
+--- Next Prompt ---
+That didn't work. When I refreshed the admin page after calling the purge endpoint, the page loads as expected. With or without the `connections` cookie, the page loads fine. 
+Is there aything else we can try to reproduce the issue locally?
+
+Time: 2026-06-02 08:21:49
+--- Codex Run ---
+
+Codex output:
+Yes. Two important points:
+
+First, refreshing after purge is expected to work. On a fresh `/admin/api/` request, `mvcSession` sees the key is gone, creates a new default MVC state, saves it, and the page loads. So the purge endpoint mainly tests what happens to an already-open SSE watcher, not the fresh-load placeholder.
+
+Try this exact flow first:
+
+```sh
+LOG_LEVEL=DEBUG CONORGANIZER_DEBUG_LIVE_UPDATES=true go tool task start
+```
+
+1. Open `/admin` and leave it open.
+2. Confirm `/admin/api/?datastar=%7B%7D` is pending in Network.
+3. Call the purge endpoint.
+4. Do not refresh.
+5. Check logs for either:
+   - `failed to unmarshal admin live update state` with `operation=KeyValuePurgeOp`, `value_bytes=0`
+   - or no watcher reaction, which would mean purge is not the same path as TTL expiry for our active stream.
+
+Second, to reproduce the visible placeholder on fresh load, the better local simulation is a **corrupt current session KV value** endpoint.
+
+That would do this:
+
+1. Use the current `connections` cookie.
+2. Write an invalid/empty value into the `events` KV bucket for that session key.
+3. Refresh `/admin`.
+
+Then `mvcSession` should hit `kv.Get`, find the bad value, fail `json.Unmarshal`, and return after SSE headers have already been flushed. That should reproduce the placeholder symptom much more directly than purge.
+
+I’d add a second debug-only endpoint:
+
+```text
+POST /admin/debug/live-updates/corrupt-current
+```
+
+Then the repro would be:
+
+```sh
+curl -i -X POST 'http://localhost:7331/admin/debug/live-updates/corrupt-current' \
+  -H "Cookie: $COOKIE"
+```
+
+After that, refresh `/admin`. This should force the “SSE starts but never patches admin content” path.
+
+Time: 2026-06-02 08:21:49
+--- Next Prompt ---
+I think we may need to add a fix without reproducing the issue locally. This is not iedeal but this is the nature of the bug.
+
+What mitigation would you suggest for the fix?
+I don't want to update the first page load loop now. Let's focus on making the live updates more robust fist. 
+You mentioned possible timing issues? 
+Let's also fix the cookie creation issue. When I visit the profile page or the events page, the `connections` cookie is created successfully. But not he root page or the admin pages.
+
+
+Let's discuss this before you start coding. If you have any clarifying questions, please ask.
+
+Time: 2026-06-02 09:09:41
+--- Codex Run ---
+
+Codex output:
+I’ll keep this in discussion mode. I’m going to re-check the exact ordering in root/admin/event/profile so the mitigation proposal matches what the code is actually doing, especially around where the `connections` cookie can be set.
+The code confirms the cookie pattern you observed: event/profile resolve the session before `NewSSE`, while root/admin currently call `NewSSE` first and can lose `Set-Cookie`. That is a concrete mitigation target independent of reproducing the full production failure.
+Yes. I’d mitigate this in layers, without touching the initial HTML/page-load loop yet.
+
+**Recommended Fix Set**
+
+1. **Move session creation before `NewSSE` on root/admin**
+
+This is the concrete cookie bug.
+
+Currently:
+
+- root calls `datastar.NewSSE` before `mvcSession`: [pages/root/root.go](/home/cinmay/Documents/conorganizer/pages/root/root.go:96)
+- admin does the same: [pages/admin/admin.go](/home/cinmay/Documents/conorganizer/pages/admin/admin.go:119)
+- event/profile do session first, then SSE: [pages/event/event.go](/home/cinmay/Documents/conorganizer/pages/event/event.go:132), [pages/profile/profile.go](/home/cinmay/Documents/conorganizer/pages/profile/profile.go:120)
+
+So root/admin can fail to send `Set-Cookie: connections=...` because `NewSSE` flushes headers immediately. I would align root/admin with event/profile.
+
+2. **Send the first patch directly, then start watching**
+
+This avoids relying on NATS `Watch` to deliver the initial value.
+
+For admin, after:
+
+```go
+sessionID, mvc, err := mvcSession(...)
+sse := datastar.NewSSE(...)
+```
+
+we should immediately patch:
+
+```go
+sse.PatchElementTempl(adminPage(db))
+```
+
+Then start `kv.Watch`.
+
+That keeps the live-update approach, but removes the brittle dependency where the first render only happens if the watcher emits an initial entry.
+
+3. **Handle KV delete/purge/TTL events explicitly**
+
+Right now watcher loops unmarshal every non-nil entry as JSON. A TTL/purge marker can have an empty value.
+
+Mitigation:
+
+```go
+if entry.Operation() != jetstream.KeyValuePut {
+    resetMVC(mvc)
+    saveMVC(...)
+    patch current page
+    continue
+}
+```
+
+For corrupt JSON, I’d also prefer reset-and-save over returning 500. The session state is reload/view state, not durable user data, so recovery is better than breaking the stream.
+
+4. **Make watcher shutdown boring**
+
+We already did this on admin, but I’d apply the same pattern to root/event/profile:
+
+- handle closed update channel
+- ignore/downgrade `nats.ErrBadSubscription` during normal request close
+- log actual watcher errors
+
+5. **Optional later: Datastar retry**
+
+The client currently may not reconnect after a clean stream close. We could consider `retry: 'always'`, but I would not start there. Server-side resilience should come first.
+
+**My Preferred Scope**
+
+First implementation pass:
+
+- root/admin: move session before SSE
+- admin/root/event/profile: handle delete/purge/corrupt KV entries without killing the stream
+- admin: send immediate first patch before watching
+- apply watcher cleanup robustness consistently
+
+I would leave the actual initial HTML/page-load loop alone for now, as requested.
+
+**Clarifying Questions**
+
+1. Should the purge/corrupt KV recovery reset state silently for all pages, or only admin/root for now?
+2. Do you want this applied only to the main admin page, or also admin subpages like approval/billettholder where they have their own live-update paths?
+3. Are you okay with keeping the debug purge endpoint behind `CONORGANIZER_DEBUG_LIVE_UPDATES`, or should we remove it once the mitigation is in?
+
+Time: 2026-06-02 09:09:41
+--- Next Prompt ---
+1. Add purge/corrupt KV recovery reset state silently for all pages. 
+2. Fix the subpages too. 
+3. Remove the debug code. I have already removed some of it via git discard. 
+
+Time: 2026-06-02 09:25:58
+--- Codex Run ---
+
+Codex output:
+I’ll implement this now, and I’ll use the `conorganizer-logging` guidance where I touch stream logs. First I’m checking the current worktree because you discarded some debug code, then I’ll update the live-update handlers consistently.
+The live-update code is split into two patterns: KV watchers for root/event/profile/admin/new-event/edit-form, and NATS subject notifications for billettholder/profile-ticket pages. I’ll fix both patterns, but the KV purge/corrupt reset logic mainly applies to the KV watcher/session helpers.
+I have the scope now. I’m going to keep the fix conservative: repair session state on bad KV entries instead of surfacing 500s, move session-before-SSE where it is currently wrong, and add immediate first patches to the long-running streams so they do not depend on watcher initial delivery.
+Starting with the root handler: it has the same cookie ordering problem as admin and still relies on the watcher for its first SSE patch. I’m changing it to resolve/save the session before SSE, patch once immediately, then watch for later updates.
+I’m also tightening the order so watcher creation errors happen before SSE headers are flushed. The target order is: session state, watcher, SSE, first patch, loop.
+Next is admin, including approval and edit-form substreams. I’m keeping the existing diagnostic logs, but changing the failure paths so purge/corrupt entries reset state and keep streaming.
+The admin file still has the diagnostic logs from the previous pass, but the debug purge endpoint is gone. I’ll reuse the logs as context and remove the parts that treated “no initial watcher state” as the only first-patch path.
+For admin I’m changing the route order to: session, watcher, SSE, immediate patch. Then the watcher loop only handles later updates and recovers from purge/corrupt entries by resetting and saving the session state.
+Now I’m updating the admin subpage KV streams: approval overview and edit form. They’ll use the same session-before-SSE ordering, send an immediate patch, and recover from invalid KV entries.
+One cleanup detail: where I create a watcher before the first patch, the deferred stop needs to be registered before patching, otherwise a rare initial patch failure could leak a watcher. I’m correcting that as I go.
+Event already creates the cookie before SSE, but it still creates the watcher after SSE and unmarshal-fails on purge/corrupt KV entries. I’m making its watcher setup and recovery match the fixed pattern.
+The event page renders from the database, so resetting the small per-session MVC state is enough; the visible event content is immediately repatched from DB state.
+Profile already sends an immediate patch for the main profile view, but I’m still moving watcher creation before SSE and adding the same KV reset behavior. The new-event subpage will get an immediate first patch too.
+I noticed the profile new-event stream still had `NewSSE` before watcher creation after the first patch. I’m moving that too so its error path stays pre-SSE.
+Now I’m fixing the NATS-subject subpages. They do not watch KV directly, but they still use the same `connections` cookie and KV-backed session snapshot, so they need session-before-SSE and corrupt-state reset.
+Applying the same subject-stream treatment to the profile tickets page: recover bad KV snapshot and create the session/subscription before opening SSE.
+There are a few `.templ` files with embedded Go handlers. I changed the profile tickets index source, and I’ll check the card handlers before running templ generation so generated Go stays consistent.
+For the card action handlers, I’m only moving `upsertSessionID` before `NewSSE`; those are not long-running streams, but this fixes the same cookie timing issue on subpage actions.
+There is one more profile tickets action that opened SSE before creating the cookie. I’m moving only the cookie creation earlier; the notification still happens after the work succeeds.
+One event action still called `mvcSession` after opening SSE. Even though the event page usually creates the cookie first, I’m moving that session touch before SSE as a defensive consistency fix.
+The source edits are in place. I’m formatting Go files, formatting the touched templ files if the templ tool supports targeted fmt, and regenerating templ output for the changed templ sources.
+The targeted templ generate reported no generated updates, which is suspicious after changing embedded Go in `.templ` files. I’m checking the diffs and generated files now; if needed I’ll run a full templ generate.
+The generated files already reflect the templ source changes, even though they did not show up as modified in git. I’m doing a code pass now for ordering mistakes and unused variables before running tests.
+The generated `_templ.go` files are not tracked in git, but they do exist locally and are used by `go test`. I’m going to run a full templ generate so the local generated tree is current, then run the affected package tests with a writable Go cache.
+Templ generation and whitespace check for the touched files passed. The affected Go tests are still running; I’m waiting for those results.
+The targeted package tests pass. I’m doing a final scan for any remaining KV watcher loops that still unmarshal raw watcher values without operation handling.
+The remaining `json.Unmarshal(entry.Value(), mvc)` hits are inside the new recovery helpers, not raw watcher loops. I’ll run the full test suite now with the writable cache; if it fails outside the touched paths I’ll call that out separately.
+The full suite is still running. I’m letting it complete rather than stopping at the package-level checks.
+The full test suite passes. I’m doing one final diff/status pass so the summary is accurate and to confirm the debug endpoint stayed removed.
+Implemented the mitigation without changing the initial HTML page-load loop.
+
+What changed:
+
+- Moved session/cookie creation before `datastar.NewSSE` for root/admin and affected subpage streams.
+- Created watchers/subscriptions before opening SSE where applicable, so setup errors happen before headers are flushed.
+- Added immediate first SSE patches for the long-running streams so they do not depend on NATS watcher initial delivery.
+- Added silent KV recovery: purge/delete/corrupt KV entries now reset and save the page session state instead of killing the SSE handler.
+- Applied the same treatment to admin approval/edit pages, billettholder admin/add pages, profile, profile new-event, profile tickets, root, and event.
+- Moved `upsertSessionID` before SSE in billettholder/profile ticket card actions.
+- Removed/kept removed the debug purge endpoint; scan confirms no `CONORGANIZER_DEBUG_LIVE_UPDATES` or debug purge route remains.
+
+Validation passed:
+
+```sh
+go tool templ generate
+GOCACHE=/tmp/conorganizer-go-build go test ./...
+git diff --check -- <touched files>
+```
+
+Note: `.ai/threads/bug-no-live-update.md` is still modified in the worktree, but I did not touch it.
+
+Time: 2026-06-02 09:25:58
+--- Next Prompt ---
 

--- a/deploy/conorganizer.service.tmpl
+++ b/deploy/conorganizer.service.tmpl
@@ -12,7 +12,8 @@ Environment=PORT=%PORT%
 
 ExecStart=/opt/conorganizer/%SAFE_NAME%/conorganizer-%SAFE_NAME% \
   -dbp /mnt/HC_Volume_103911252/environments/%SAFE_NAME%/database/events.db \
-  -image-path /mnt/HC_Volume_103911252/environments/%SAFE_NAME%/event-images
+  -image-path /mnt/HC_Volume_103911252/environments/%SAFE_NAME%/event-images \
+  -nats-store /mnt/HC_Volume_103911252/environments/%SAFE_NAME%/nats
 
 Restart=always
 RestartSec=5

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -31,6 +31,7 @@ BRANCH_DATA_DIR="$DATA_ROOT/$SAFE_NAME"
 BRANCH_DB_DIR="$BRANCH_DATA_DIR/database"
 BRANCH_DB_FILE="$BRANCH_DB_DIR/events.db"
 BRANCH_IMG_DIR="$BRANCH_DATA_DIR/event-images"
+BRANCH_NATS_DIR="$BRANCH_DATA_DIR/nats"
 MAIN_DB_FILE="$MAIN_DATA_DIR/database/events.db"
 
 SERVICE_USER="deploy"
@@ -97,6 +98,11 @@ if [[ "$SAFE_NAME" != "main" ]]; then
   else
     echo "[deploy] Event-images dir already exists for branch: $BRANCH_IMG_DIR (skipping copy)"
   fi
+
+  # Each environment needs its own NATS JetStream store; never clone main's store
+  # (sharing/locking it across instances is the bug we are fixing, see issue #386).
+  echo "[deploy] Ensuring NATS store directory for branch: $BRANCH_NATS_DIR"
+  mkdir -p "$BRANCH_NATS_DIR"
 
   chown -R "$SERVICE_USER:$SERVICE_GROUP" "$BRANCH_DATA_DIR"
 else

--- a/health.go
+++ b/health.go
@@ -18,6 +18,7 @@ const (
 	notReadyApplicationReason = "application startup incomplete"
 	notReadyDatabaseReason    = "database not available"
 	notReadyImageReason       = "image directory not writable"
+	notReadyNatsReason        = "nats store directory not writable"
 	notReadyMultipleReason    = "multiple startup checks failed"
 )
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	dsn := flag.String("dbp", "database/events.db", "absolute path to database file")
 	eventImageDir := flag.String("image-path", "local-event-images", "directory to store event images")
+	natsStoreDir := flag.String("nats-store", "data/nats", "directory for embedded NATS JetStream storage")
 	flag.Parse()
 
 	db, dbErr := service.InitDB(*dsn)
@@ -60,21 +61,21 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, baseLogger, getPort(), eventImageDir, db); err != nil {
+	if err := run(ctx, baseLogger, getPort(), eventImageDir, natsStoreDir, db); err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, logger *slog.Logger, port string, eventImageDir *string, db *sql.DB) error {
+func run(ctx context.Context, logger *slog.Logger, port string, eventImageDir *string, natsStoreDir *string, db *sql.DB) error {
 	g, ctx := errgroup.WithContext(ctx)
-	g.Go(startServer(ctx, logger, port, eventImageDir, db))
+	g.Go(startServer(ctx, logger, port, eventImageDir, natsStoreDir, db))
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("error running server: %w", err)
 	}
 	return nil
 }
-func startServer(ctx context.Context, logger *slog.Logger, port string, eventImageDir *string, db *sql.DB) func() error {
+func startServer(ctx context.Context, logger *slog.Logger, port string, eventImageDir *string, natsStoreDir *string, db *sql.DB) func() error {
 	return func() error {
 		baseLogger := logger
 		logger = logger.With("component", "http_server")
@@ -98,11 +99,27 @@ func startServer(ctx context.Context, logger *slog.Logger, port string, eventIma
 			imgErr = fmt.Errorf("event image directory path is empty")
 		}
 
+		var natsErr error
+		if natsStoreDir != nil && *natsStoreDir != "" {
+			// NATS would create this itself, but pre-creating lets the writable check run
+			// and fail loudly here instead of NATS silently falling back to a temp dir.
+			if err := os.MkdirAll(*natsStoreDir, 0o755); err != nil {
+				natsErr = fmt.Errorf("could not create NATS store directory %q: %w", *natsStoreDir, err)
+			} else if err := service.CheckWritableDirectory(*natsStoreDir); err != nil {
+				natsErr = fmt.Errorf("NATS store directory startup check failed: %w", err)
+			}
+		} else {
+			natsErr = fmt.Errorf("NATS store directory path is empty")
+		}
+
 		degradedErr := imgErr
-		fullMode := degradedErr == nil && db != nil
 		if degradedErr != nil {
 			readiness.MarkDegraded(notReadyImageReason, degradedErr)
+		} else if natsErr != nil {
+			degradedErr = natsErr
+			readiness.MarkDegraded(notReadyNatsReason, degradedErr)
 		}
+		fullMode := degradedErr == nil && db != nil
 
 		var appRouter chi.Router = router
 		if fullMode {
@@ -115,7 +132,7 @@ func startServer(ctx context.Context, logger *slog.Logger, port string, eventIma
 		appRouter.Handle("/static/*", http.StripPrefix("/static/", static(baseLogger)))
 
 		if fullMode {
-			cleanup, err := setupRoutes(ctx, baseLogger, appRouter, db, eventImageDir)
+			cleanup, err := setupRoutes(ctx, baseLogger, appRouter, db, eventImageDir, natsStoreDir)
 			if err != nil {
 				logger.Error(fmt.Errorf("error setting up routes; falling back to degraded mode: %w", err).Error())
 				readiness.MarkDegraded(notReadyApplicationReason, err)

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -46,7 +46,7 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 		Bucket:      "events",
 		Description: "Regncon Event Store",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -20,8 +21,10 @@ import (
 	roomService "github.com/Regncon/conorganizer/service/rooms"
 	"github.com/delaneyj/toolbelt/embeddednats"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -96,42 +99,147 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 		puljefordelingStatusRoute(adminRouter, db, kv, logger)
 		programPublishingRoute(adminRouter, db, kv, logger)
 		adminRouter.Get("/api/", func(w http.ResponseWriter, r *http.Request) {
+			requestID := middleware.GetReqID(r.Context())
+			_, connectionsCookieErr := r.Cookie("connections")
+			connectionsCookiePresent := connectionsCookieErr == nil
+			if connectionsCookiePresent {
+				logger.Debug(
+					"admin live update stream starting",
+					"request_id", requestID,
+					"connections_cookie_present", true,
+				)
+			} else {
+				logger.Warn(
+					"admin live update stream missing connections cookie",
+					"request_id", requestID,
+					"connections_cookie_present", false,
+				)
+			}
+
 			sse := datastar.NewSSE(w, r)
 
 			sessionID, mvc, err := mvcSession(w, r)
 			if err != nil {
+				logger.Error(
+					err.Error(),
+					"request_id", requestID,
+					"connections_cookie_present", connectionsCookiePresent,
+				)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 			ctx := r.Context()
 			watcher, err := kv.Watch(ctx, sessionID)
 			if err != nil {
+				logger.Error(
+					fmt.Errorf("failed to create admin watcher: %w", err).Error(),
+					"request_id", requestID,
+					"connections_cookie_present", connectionsCookiePresent,
+				)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			logger.Debug(
+				"admin watcher started",
+				"request_id", requestID,
+				"connections_cookie_present", connectionsCookiePresent,
+			)
 			defer func() {
 				if err := watcher.Stop(); err != nil {
-					logger.Error(fmt.Errorf("failed to stop admin watcher: %w", err).Error())
+					if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+						logger.Debug(
+							"admin watcher already stopped",
+							"request_id", requestID,
+							"connections_cookie_present", connectionsCookiePresent,
+							"error", err.Error(),
+						)
+						return
+					}
+					logger.Error(
+						fmt.Errorf("failed to stop admin watcher: %w", err).Error(),
+						"request_id", requestID,
+						"connections_cookie_present", connectionsCookiePresent,
+					)
 				}
 			}()
 
+			patchSent := false
 			for {
 				select {
 				case <-ctx.Done():
+					logger.Debug(
+						"admin live update stream closed",
+						"request_id", requestID,
+						"connections_cookie_present", connectionsCookiePresent,
+						"reason", ctx.Err().Error(),
+					)
 					return
-				case entry := <-watcher.Updates():
+				case entry, ok := <-watcher.Updates():
+					if !ok {
+						if ctx.Err() != nil {
+							logger.Debug(
+								"admin watcher updates channel closed",
+								"request_id", requestID,
+								"connections_cookie_present", connectionsCookiePresent,
+								"reason", ctx.Err().Error(),
+							)
+							return
+						}
+						logger.Warn(
+							"admin watcher updates channel closed",
+							"request_id", requestID,
+							"connections_cookie_present", connectionsCookiePresent,
+						)
+						return
+					}
 					if entry == nil {
+						if !patchSent {
+							logger.Warn(
+								"admin watcher delivered no initial state",
+								"request_id", requestID,
+								"connections_cookie_present", connectionsCookiePresent,
+							)
+							continue
+						}
+						logger.Debug(
+							"admin watcher initial values delivered",
+							"request_id", requestID,
+							"connections_cookie_present", connectionsCookiePresent,
+						)
 						continue
 					}
 					if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+						logger.Error(
+							fmt.Errorf("failed to unmarshal admin live update state: %w", err).Error(),
+							"request_id", requestID,
+							"connections_cookie_present", connectionsCookiePresent,
+							"operation", entry.Operation().String(),
+							"revision", entry.Revision(),
+							"value_bytes", len(entry.Value()),
+						)
 						http.Error(w, err.Error(), http.StatusInternalServerError)
 						return
 					}
 					c := adminPage(db)
 					if err := sse.PatchElementTempl(c); err != nil {
+						logger.Error(
+							fmt.Errorf("failed to patch admin live update: %w", err).Error(),
+							"request_id", requestID,
+							"connections_cookie_present", connectionsCookiePresent,
+							"operation", entry.Operation().String(),
+							"revision", entry.Revision(),
+						)
 						_ = sse.ConsoleError(err)
 						return
 					}
+					logger.Debug(
+						"admin live update patch sent",
+						"request_id", requestID,
+						"connections_cookie_present", connectionsCookiePresent,
+						"operation", entry.Operation().String(),
+						"revision", entry.Revision(),
+					)
+					patchSent = true
 				}
 			}
 		})

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -66,6 +66,26 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 		mvc.EditingIdx = -1
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, mvc *root.TodoMVC, sessionID string) error {
+		resetMVC(mvc)
+		if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, mvc *root.TodoMVC, sessionID string, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting admin live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting admin live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		return nil
+	}
+
 	mvcSession := func(w http.ResponseWriter, r *http.Request) (string, *root.TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -78,14 +98,12 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 			if err != jetstream.ErrKeyNotFound {
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
-			resetMVC(mvc)
-
-			if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, mvc, sessionID); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -102,21 +120,11 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 			requestID := middleware.GetReqID(r.Context())
 			_, connectionsCookieErr := r.Cookie("connections")
 			connectionsCookiePresent := connectionsCookieErr == nil
-			if connectionsCookiePresent {
-				logger.Debug(
-					"admin live update stream starting",
-					"request_id", requestID,
-					"connections_cookie_present", true,
-				)
-			} else {
-				logger.Warn(
-					"admin live update stream missing connections cookie",
-					"request_id", requestID,
-					"connections_cookie_present", false,
-				)
-			}
-
-			sse := datastar.NewSSE(w, r)
+			logger.Debug(
+				"admin live update stream starting",
+				"request_id", requestID,
+				"connections_cookie_present", connectionsCookiePresent,
+			)
 
 			sessionID, mvc, err := mvcSession(w, r)
 			if err != nil {
@@ -139,11 +147,6 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			logger.Debug(
-				"admin watcher started",
-				"request_id", requestID,
-				"connections_cookie_present", connectionsCookiePresent,
-			)
 			defer func() {
 				if err := watcher.Stop(); err != nil {
 					if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
@@ -162,8 +165,22 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 					)
 				}
 			}()
+			sse := datastar.NewSSE(w, r)
+			if err := sse.PatchElementTempl(adminPage(db)); err != nil {
+				logger.Error(
+					fmt.Errorf("failed to patch initial admin live update: %w", err).Error(),
+					"request_id", requestID,
+					"connections_cookie_present", connectionsCookiePresent,
+				)
+				_ = sse.ConsoleError(err)
+				return
+			}
+			logger.Debug(
+				"admin watcher started",
+				"request_id", requestID,
+				"connections_cookie_present", connectionsCookiePresent,
+			)
 
-			patchSent := false
 			for {
 				select {
 				case <-ctx.Done():
@@ -193,14 +210,6 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 						return
 					}
 					if entry == nil {
-						if !patchSent {
-							logger.Warn(
-								"admin watcher delivered no initial state",
-								"request_id", requestID,
-								"connections_cookie_present", connectionsCookiePresent,
-							)
-							continue
-						}
 						logger.Debug(
 							"admin watcher initial values delivered",
 							"request_id", requestID,
@@ -208,9 +217,9 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 						)
 						continue
 					}
-					if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+					if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 						logger.Error(
-							fmt.Errorf("failed to unmarshal admin live update state: %w", err).Error(),
+							err.Error(),
 							"request_id", requestID,
 							"connections_cookie_present", connectionsCookiePresent,
 							"operation", entry.Operation().String(),
@@ -220,8 +229,7 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 						http.Error(w, err.Error(), http.StatusInternalServerError)
 						return
 					}
-					c := adminPage(db)
-					if err := sse.PatchElementTempl(c); err != nil {
+					if err := sse.PatchElementTempl(adminPage(db)); err != nil {
 						logger.Error(
 							fmt.Errorf("failed to patch admin live update: %w", err).Error(),
 							"request_id", requestID,
@@ -239,7 +247,6 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 						"operation", entry.Operation().String(),
 						"revision", entry.Revision(),
 					)
-					patchSent = true
 				}
 			}
 		})
@@ -247,8 +254,6 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 		adminRouter.Route("/approval/", func(approvalRouter chi.Router) {
 			approvalRouter.Route("/api/", func(apiRouter chi.Router) {
 				apiRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
-					sse := datastar.NewSSE(w, r)
-
 					sessionID, mvc, err := mvcSession(w, r)
 					if err != nil {
 						logger.Error(fmt.Errorf("failed to get approval MVC session: %w", err).Error())
@@ -264,24 +269,34 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 					}
 					defer func() {
 						if err := watcher.Stop(); err != nil {
+							if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+								return
+							}
 							logger.Error(fmt.Errorf("failed to stop approval watcher: %w", err).Error())
 						}
 					}()
+					sse := datastar.NewSSE(w, r)
+					if err := sse.PatchElementTempl(approval.ApprovalPage(db, baseLogger)); err != nil {
+						_ = sse.ConsoleError(err)
+						return
+					}
 
 					for {
 						select {
 						case <-ctx.Done():
 							return
-						case entry := <-watcher.Updates():
+						case entry, ok := <-watcher.Updates():
+							if !ok {
+								return
+							}
 							if entry == nil {
 								continue
 							}
-							if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+							if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 								http.Error(w, err.Error(), http.StatusInternalServerError)
 								return
 							}
-							c := approval.ApprovalPage(db, baseLogger)
-							if err := sse.PatchElementTempl(c); err != nil {
+							if err := sse.PatchElementTempl(approval.ApprovalPage(db, baseLogger)); err != nil {
 								_ = sse.ConsoleError(err)
 								return
 							}
@@ -443,8 +458,6 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 							return
 						}
 
-						sse := datastar.NewSSE(w, r)
-
 						ctx := r.Context()
 						watcher, err := kv.Watch(ctx, sessionID)
 						if err != nil {
@@ -453,20 +466,31 @@ func SetupAdminRoute(router chi.Router, store sessions.Store, logger *slog.Logge
 						}
 						defer func() {
 							if err := watcher.Stop(); err != nil {
+								if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+									return
+								}
 								logger.Error(fmt.Errorf("failed to stop edit-form watcher: %w", err).Error())
 							}
 						}()
+						sse := datastar.NewSSE(w, r)
+						if err := sse.PatchElementTempl(edit_form.EditEventFormPage(ctx, eventId, db, eventImageDir, baseLogger)); err != nil {
+							_ = sse.ConsoleError(err)
+							return
+						}
 
 						for {
 							select {
 							case <-ctx.Done():
 								return
-							case entry := <-watcher.Updates():
+							case entry, ok := <-watcher.Updates():
+								if !ok {
+									return
+								}
 
 								if entry == nil {
 									continue
 								}
-								if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+								if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 									http.Error(w, err.Error(), http.StatusInternalServerError)
 									return
 								}

--- a/pages/admin/billettholder_admin/billettholder_admin.go
+++ b/pages/admin/billettholder_admin/billettholder_admin.go
@@ -39,7 +39,7 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 		Bucket:      "billettholder",
 		Description: "Billettholder data",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 	if err != nil {

--- a/pages/admin/billettholder_admin/billettholder_admin.go
+++ b/pages/admin/billettholder_admin/billettholder_admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -52,6 +54,26 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 		}
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, mvc *root.TodoMVC, sessionID string) error {
+		*mvc = root.TodoMVC{}
+		if err := saveMVC(ctx, mvc, sessionID, kv, notifyUpdate); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, mvc *root.TodoMVC, sessionID string, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting billettholder admin live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting billettholder admin live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		return nil
+	}
+
 	session := func(w http.ResponseWriter, r *http.Request) (string, *root.TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -65,12 +87,12 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
 			// first visit ⇒ create an empty snapshot so the SSE loop can unmarshal
-			if err := saveMVC(ctx, mvc, sessionID, kv, notifyUpdate); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, mvc, sessionID); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -80,7 +102,6 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 
 	router.Route("/admin/billettholder/api/", func(billettholderAdminRouter chi.Router) {
 		billettholderAdminRouter.With(authctx.RequireAdmin(baseLogger)).Get("/", func(w http.ResponseWriter, r *http.Request) {
-			sse := datastar.NewSSE(w, r)
 			sessionID, _, err := session(w, r)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -96,9 +117,13 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 			}
 			defer func() {
 				if err := sub.Unsubscribe(); err != nil {
+					if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+						return
+					}
 					logger.Error(fmt.Errorf("failed to unsubscribe billettholder admin stream: %w", err).Error())
 				}
 			}()
+			sse := datastar.NewSSE(w, r)
 
 			// send the first render immediately
 			if err := sse.PatchElementTempl(BillettholderAdminPage(db, logger)); err != nil {
@@ -125,7 +150,6 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 
 	router.Route("/admin/billettholder/add/api/", func(addBillettholderRouter chi.Router) {
 		addBillettholderRouter.With(authctx.RequireAdmin(baseLogger)).Get("/", func(w http.ResponseWriter, r *http.Request) {
-			sse := datastar.NewSSE(w, r)
 			sessionID, _, err := session(w, r)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -142,9 +166,13 @@ func SetupBillettholderAdminRoute(router chi.Router, store sessions.Store, ns *e
 			}
 			defer func() {
 				if err := sub.Unsubscribe(); err != nil {
+					if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+						return
+					}
 					logger.Error(fmt.Errorf("failed to unsubscribe add-billettholder stream: %w", err).Error())
 				}
 			}()
+			sse := datastar.NewSSE(w, r)
 
 			// initial render
 			if err := sse.PatchElementTempl(addbillettholder.AddBillettholderAdminPage(db, logger)); err != nil {

--- a/pages/admin/billettholder_admin/billettholder_card.templ
+++ b/pages/admin/billettholder_admin/billettholder_card.templ
@@ -69,13 +69,13 @@ func handleError(responder Responder, dispalyText string, errorText string) {
 		return
 	}
 
+	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	sse := datastar.NewSSE(responder.w, responder.r)
 	if err := sse.PatchSignals(b); err != nil {
 		responder.Logger.Error("Failed to patch signals", "error", err)
 		http.Error(responder.w, "Failed to patch signals", http.StatusInternalServerError)
 		return
 	}
-	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	if responder.NotifyUpdate != nil {
 		responder.NotifyUpdate(sessionID)
 	}
@@ -98,6 +98,7 @@ func handleSuccess(responder Responder, successText string) {
 		return
 	}
 
+	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	sse := datastar.NewSSE(responder.w, responder.r)
 	if err := sse.PatchSignals(b); err != nil {
 		responder.Logger.Error("Failed to patch signals", "error", err)
@@ -105,7 +106,6 @@ func handleSuccess(responder Responder, successText string) {
 		return
 	}
 
-	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	if responder.NotifyUpdate != nil {
 		responder.NotifyUpdate(sessionID)
 	}

--- a/pages/event/event.go
+++ b/pages/event/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -97,6 +99,26 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 		mvc.EditingIdx = -1
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, mvc *root.TodoMVC, sessionID string) error {
+		resetMVC(mvc)
+		if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, mvc *root.TodoMVC, sessionID string, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting event live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting event live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		return nil
+	}
+
 	mvcSession := func(w http.ResponseWriter, r *http.Request) (string, *root.TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -109,14 +131,12 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 			if err != jetstream.ErrKeyNotFound {
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
-			resetMVC(mvc)
-
-			if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, mvc, sessionID); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -135,9 +155,6 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 					return
 				}
 
-				sse := datastar.NewSSE(w, r)
-
-				// Watch for updates
 				ctx := r.Context()
 				watcher, err := kv.Watch(ctx, sessionID)
 				if err != nil {
@@ -146,26 +163,38 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 				}
 				defer func() {
 					if err := watcher.Stop(); err != nil {
+						if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+							return
+						}
 						logger.Error(fmt.Errorf("failed to stop event watcher: %w", err).Error())
 					}
 				}()
+				sse := datastar.NewSSE(w, r)
+				renderEventPage := func() error {
+					isAdmin := authctx.GetAdminFromUserToken(ctx)
+					return sse.PatchElementTempl(event_page(eventID, isAdmin, logger, db, eventImageDir, r))
+				}
+				if err := renderEventPage(); err != nil {
+					_ = sse.ConsoleError(err)
+					return
+				}
 
 				for {
 					select {
 					case <-ctx.Done():
 						return
-					case entry := <-watcher.Updates():
+					case entry, ok := <-watcher.Updates():
+						if !ok {
+							return
+						}
 						if entry == nil {
 							continue
 						}
-						if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+						if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 							http.Error(w, err.Error(), http.StatusInternalServerError)
 							return
 						}
-						isAdmin := authctx.GetAdminFromUserToken(ctx)
-						c := event_page(eventID, isAdmin, logger, db, eventImageDir, r)
-
-						if err := sse.PatchElementTempl(c); err != nil {
+						if err := renderEventPage(); err != nil {
 							_ = sse.ConsoleError(err)
 							return
 						}
@@ -220,6 +249,10 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 						}
 						ctx := r.Context()
 						userInfo := userctx.GetUserRequestInfo(ctx)
+						if _, _, mvcErr := mvcSession(w, r); mvcErr != nil {
+							http.Error(w, mvcErr.Error(), http.StatusInternalServerError)
+							return
+						}
 						sse := datastar.NewSSE(w, r)
 
 						eventId := chi.URLParam(r, "idx")
@@ -242,13 +275,6 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 							if err := patchInterestErrorSignal(sse, "Vel pulje f\u00f8r du melder interesse."); err != nil {
 								logger.Error(err.Error(), "event_id", eventId, "user_id", userInfo.Id, "billettholder_id", signals.BillettHolderId)
 							}
-							return
-						}
-
-						_, _, mvcErr := mvcSession(w, r)
-
-						if mvcErr != nil {
-							http.Error(w, mvcErr.Error(), http.StatusInternalServerError)
 							return
 						}
 

--- a/pages/event/event.go
+++ b/pages/event/event.go
@@ -76,7 +76,7 @@ func SetupEventRoute(router chi.Router, store sessions.Store, ns *embeddednats.S
 		Bucket:      "events",
 		Description: "Regncon Event Store",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 

--- a/pages/profile/profile.go
+++ b/pages/profile/profile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -53,6 +55,26 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 		return fmt.Errorf("error creating key value: %w", err)
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, mvc *root.TodoMVC, sessionID string) error {
+		*mvc = root.TodoMVC{}
+		if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, mvc *root.TodoMVC, sessionID string, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting profile live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting profile live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		return nil
+	}
+
 	profileSession := func(w http.ResponseWriter, r *http.Request) (string, *root.TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -66,12 +88,12 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
 
-			if err := saveMVC(ctx, mvc, sessionID, kv); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, mvc, sessionID); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -123,7 +145,6 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 					return
 				}
 
-				sse := datastar.NewSSE(w, r)
 				ctx := r.Context()
 				user := userctx.GetUserRequestInfo(ctx)
 				watcher, err := kv.Watch(ctx, sessionID)
@@ -133,9 +154,13 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 				}
 				defer func() {
 					if err := watcher.Stop(); err != nil {
+						if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+							return
+						}
 						requestLogger.Error(fmt.Errorf("failed to stop profile watcher: %w", err).Error())
 					}
 				}()
+				sse := datastar.NewSSE(w, r)
 
 				renderProfileMainColumn := func() error {
 					events := GetEventsByExternalID(user.Id, db, requestLogger)
@@ -156,11 +181,14 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 					select {
 					case <-ctx.Done():
 						return
-					case entry := <-watcher.Updates():
+					case entry, ok := <-watcher.Updates():
+						if !ok {
+							return
+						}
 						if entry == nil {
 							continue
 						}
-						if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+						if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 							http.Error(w, err.Error(), http.StatusInternalServerError)
 							return
 						}
@@ -191,8 +219,6 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 							return
 						}
 
-						sse := datastar.NewSSE(w, r)
-
 						ctx := r.Context()
 						watcher, err := kv.Watch(ctx, sessionID)
 						if err != nil {
@@ -201,28 +227,40 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 						}
 						defer func() {
 							if err := watcher.Stop(); err != nil {
+								if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+									return
+								}
 								logger.Error(fmt.Errorf("failed to stop new-event watcher: %w", err).Error())
 							}
 						}()
+						sse := datastar.NewSSE(w, r)
+						renderNewEventForm := func() error {
+							userId := userctx.GetUserRequestInfo(r.Context()).Id
+							return sse.PatchElementTempl(newevent.NewEventFormPage(eventId, userId, ctx, db, eventImageDir, logger))
+						}
+						if err := renderNewEventForm(); err != nil {
+							_ = sse.ConsoleError(err)
+							return
+						}
 
 						for {
 							select {
 							case <-ctx.Done():
 								return
-							case entry := <-watcher.Updates():
+							case entry, ok := <-watcher.Updates():
+								if !ok {
+									return
+								}
 
 								if entry == nil {
 									continue
 								}
-								if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+								if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
 									http.Error(w, err.Error(), http.StatusInternalServerError)
 									return
 								}
 
-								userId := userctx.GetUserRequestInfo(r.Context()).Id
-
-								c := newevent.NewEventFormPage(eventId, userId, ctx, db, eventImageDir, logger)
-								if err := sse.PatchElementTempl(c); err != nil {
+								if err := renderNewEventForm(); err != nil {
 									_ = sse.ConsoleError(err)
 									return
 								}

--- a/pages/profile/profile.go
+++ b/pages/profile/profile.go
@@ -48,7 +48,7 @@ func SetupProfileRoute(router chi.Router, store sessions.Store, ns *embeddednats
 		Bucket:      "events",
 		Description: "Regncon Event Store",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 	if err != nil {

--- a/pages/profile/tickets/billettholder_profile_card.templ
+++ b/pages/profile/tickets/billettholder_profile_card.templ
@@ -41,13 +41,13 @@ func handleError(responder Responder, dispalyText string, errorText string) {
 		return
 	}
 
+	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	sse := datastar.NewSSE(responder.w, responder.r)
 	if err := sse.PatchSignals(b); err != nil {
 		responder.Logger.Error("Failed to patch signals", "error", err)
 		http.Error(responder.w, "Failed to patch signals", http.StatusInternalServerError)
 		return
 	}
-	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	if responder.NotifyUpdate != nil {
 		responder.NotifyUpdate(sessionID)
 	}
@@ -70,6 +70,7 @@ func handleSuccess(responder Responder, successText string) {
 		return
 	}
 
+	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	sse := datastar.NewSSE(responder.w, responder.r)
 	if err := sse.PatchSignals(b); err != nil {
 		responder.Logger.Error("Failed to patch signals", "error", err)
@@ -77,7 +78,6 @@ func handleSuccess(responder Responder, successText string) {
 		return
 	}
 
-	sessionID, _ := upsertSessionID(responder.Store, responder.r, responder.w)
 	if responder.NotifyUpdate != nil {
 		responder.NotifyUpdate(sessionID)
 	}

--- a/pages/profile/tickets/tickets_index.templ
+++ b/pages/profile/tickets/tickets_index.templ
@@ -39,7 +39,7 @@ func ProfileTicketsRoute(router chi.Router, store sessions.Store, ns *embeddedna
 		Bucket:      "billettholder",
 		Description: "Billettholder data",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 	if err != nil {

--- a/pages/profile/tickets/tickets_index.templ
+++ b/pages/profile/tickets/tickets_index.templ
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -52,6 +54,26 @@ func ProfileTicketsRoute(router chi.Router, store sessions.Store, ns *embeddedna
 		}
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, mvc *root.TodoMVC, sessionID string) error {
+		*mvc = root.TodoMVC{}
+		if err := saveMVC(ctx, mvc, sessionID, kv, notifyUpdate); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, mvc *root.TodoMVC, sessionID string, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting profile tickets live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting profile tickets live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, mvc, sessionID)
+		}
+		return nil
+	}
+
 	session := func(w http.ResponseWriter, r *http.Request) (string, *root.TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -65,12 +87,12 @@ func ProfileTicketsRoute(router chi.Router, store sessions.Store, ns *embeddedna
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
 			// first visit ⇒ create an empty snapshot so the SSE loop can unmarshal
-			if err := saveMVC(ctx, mvc, sessionID, kv, notifyUpdate); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, mvc, sessionID); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, mvc, sessionID, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -90,7 +112,6 @@ func ProfileTicketsRoute(router chi.Router, store sessions.Store, ns *embeddedna
 		})
 		profileRouter.Route("/api", func(billettholderAdminRouter chi.Router) {
 			billettholderAdminRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				sse := datastar.NewSSE(w, r)
 				sessionID, _, err := session(w, r)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -104,9 +125,17 @@ func ProfileTicketsRoute(router chi.Router, store sessions.Store, ns *embeddedna
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
-				defer sub.Unsubscribe()
+				defer func() {
+					if err := sub.Unsubscribe(); err != nil {
+						if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+							return
+						}
+						logger.Error(fmt.Errorf("failed to unsubscribe profile tickets stream: %w", err).Error())
+					}
+				}()
 
 				var user = userctx.GetUserRequestInfo(ctx)
+				sse := datastar.NewSSE(w, r)
 				// send the first render immediately
 				if err := sse.PatchElementTempl(profileTicketsPage(user.Id, db, logger)); err != nil {
 					_ = sse.ConsoleError(err)

--- a/pages/profile/tickets/tickets_page.templ
+++ b/pages/profile/tickets/tickets_page.templ
@@ -30,9 +30,10 @@ func getTicketsRouter(
 	notifyUpdate func(string),
 ) {
 	router.Post("/get-tickets", func(w http.ResponseWriter, r *http.Request) {
-		sse := datastar.NewSSE(w, r)
 		var ctx = r.Context()
 		var user = userctx.GetUserRequestInfo(ctx)
+		sessionID, _ := upsertSessionID(store, r, w)
+		sse := datastar.NewSSE(w, r)
 
 		var errorMessage = ""
 
@@ -76,7 +77,6 @@ func getTicketsRouter(
 			return
 		}
 
-		sessionID, _ := upsertSessionID(store, r, w)
 		if notifyUpdate != nil {
 			notifyUpdate(sessionID)
 		}

--- a/pages/root/root.go
+++ b/pages/root/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	datastar "github.com/starfederation/datastar-go/datastar"
 )
@@ -65,6 +67,26 @@ func SetupRootRoute(router chi.Router, store sessions.Store, logger *slog.Logger
 		mvc.EditingIdx = -1
 	}
 
+	resetAndSaveMVC := func(ctx context.Context, sessionID string, mvc *TodoMVC) error {
+		resetMVC(mvc)
+		if err := saveMVC(ctx, sessionID, mvc); err != nil {
+			return fmt.Errorf("failed to save mvc: %w", err)
+		}
+		return nil
+	}
+
+	applyMVCEntry := func(ctx context.Context, sessionID string, mvc *TodoMVC, entry jetstream.KeyValueEntry) error {
+		if entry.Operation() != jetstream.KeyValuePut {
+			logger.Debug("resetting root live update state after KV operation", "operation", entry.Operation().String())
+			return resetAndSaveMVC(ctx, sessionID, mvc)
+		}
+		if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+			logger.Debug("resetting root live update state after invalid KV value", "error", err.Error())
+			return resetAndSaveMVC(ctx, sessionID, mvc)
+		}
+		return nil
+	}
+
 	mvcSession := func(w http.ResponseWriter, r *http.Request) (string, *TodoMVC, error) {
 		ctx := r.Context()
 		sessionID, err := upsertSessionID(store, r, w)
@@ -77,14 +99,12 @@ func SetupRootRoute(router chi.Router, store sessions.Store, logger *slog.Logger
 			if err != jetstream.ErrKeyNotFound {
 				return "", nil, fmt.Errorf("failed to get key value: %w", err)
 			}
-			resetMVC(mvc)
-
-			if err := saveMVC(ctx, sessionID, mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to save mvc: %w", err)
+			if err := resetAndSaveMVC(ctx, sessionID, mvc); err != nil {
+				return "", nil, err
 			}
 		} else {
-			if err := json.Unmarshal(entry.Value(), mvc); err != nil {
-				return "", nil, fmt.Errorf("failed to unmarshal mvc: %w", err)
+			if err := applyMVCEntry(ctx, sessionID, mvc, entry); err != nil {
+				return "", nil, err
 			}
 		}
 		return sessionID, mvc, nil
@@ -94,8 +114,6 @@ func SetupRootRoute(router chi.Router, store sessions.Store, logger *slog.Logger
 	router.Route("/root", func(rootRouter chi.Router) {
 		rootRouter.Route("/api", func(rootApiRouter chi.Router) {
 			rootApiRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				sse := datastar.NewSSE(w, r)
-
 				sessionID, mvc, err := mvcSession(w, r)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -109,26 +127,38 @@ func SetupRootRoute(router chi.Router, store sessions.Store, logger *slog.Logger
 				}
 				defer func() {
 					if err := watcher.Stop(); err != nil {
+						if errors.Is(err, nats.ErrBadSubscription) || ctx.Err() != nil {
+							return
+						}
 						logger.Error(fmt.Errorf("failed to stop root watcher: %w", err).Error())
 					}
 				}()
+				sse := datastar.NewSSE(w, r)
+				renderRootPage := func() error {
+					isAdmin := authctx.GetAdminFromUserToken(ctx)
+					return sse.PatchElementTempl(rootPage(db, isAdmin, eventImageDir))
+				}
+				if err := renderRootPage(); err != nil {
+					_ = sse.ConsoleError(err)
+					return
+				}
 
 				for {
 					select {
 					case <-ctx.Done():
 						return
-					case entry := <-watcher.Updates():
+					case entry, ok := <-watcher.Updates():
+						if !ok {
+							return
+						}
 						if entry == nil {
 							continue
 						}
-						if err := json.Unmarshal(entry.Value(), mvc); err != nil {
+						if err := applyMVCEntry(ctx, sessionID, mvc, entry); err != nil {
 							http.Error(w, err.Error(), http.StatusInternalServerError)
 							return
 						}
-						var ctx = r.Context()
-						isAdmin := authctx.GetAdminFromUserToken(ctx)
-						c := rootPage(db, isAdmin, eventImageDir)
-						if err := sse.PatchElementTempl(c); err != nil {
+						if err := renderRootPage(); err != nil {
 							_ = sse.ConsoleError(err)
 							return
 						}

--- a/pages/root/root.go
+++ b/pages/root/root.go
@@ -36,7 +36,7 @@ func SetupRootRoute(router chi.Router, store sessions.Store, logger *slog.Logger
 		Bucket:      "events",
 		Description: "Regncon Event Store",
 		Compression: true,
-		TTL:         time.Hour,
+		TTL:         24 * time.Hour, // match the "connections" cookie lifetime so open pages keep state
 		MaxBytes:    16 * 1024 * 1024,
 	})
 

--- a/router.go
+++ b/router.go
@@ -24,20 +24,32 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/server"
 )
 
-func setupRoutes(ctx context.Context, logger *slog.Logger, router chi.Router, db *sql.DB, eventImageDir *string) (cleanup func() error, err error) {
+func setupRoutes(ctx context.Context, logger *slog.Logger, router chi.Router, db *sql.DB, eventImageDir *string, natsStoreDir *string) (cleanup func() error, err error) {
 	natsPort, err := toolbelt.FreePort()
 	if err != nil {
 		return nil, fmt.Errorf("error getting free port: %w", err)
 	}
 
+	storeDir := ""
+	if natsStoreDir != nil {
+		storeDir = *natsStoreDir
+	}
+
+	// StoreDir must be set explicitly: when left empty NATS defaults JetStream storage to
+	// os.TempDir()/jetstream, which every co-located instance shares and locks against each
+	// other, and which /tmp cleanup wipes. A per-instance persistent dir keeps live updates
+	// stable. See https://github.com/Regncon/conorganizer/issues/386.
 	ns, err := embeddednats.New(ctx, embeddednats.WithNATSServerOptions(&natsserver.Options{
 		JetStream: true,
 		Port:      natsPort,
+		StoreDir:  storeDir,
 	}))
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating embedded nats server: %w", err)
 	}
+
+	logger.Info("embedded NATS JetStream initialized", "store_dir", storeDir, "port", natsPort)
 
 	ns.WaitForServer()
 


### PR DESCRIPTION
## Why

Closes #386. Live-update SSE streams silently stop "on machines" (admin shows *"clear your cookies and refresh"*), but never on localhost.

**Root cause — the JetStream store directory.** The embedded NATS server was started with no `StoreDir`, so JetStream defaults to `os.TempDir()/jetstream` → **`/tmp/jetstream`** (`nats-server .../server/jetstream.go:224-225`). The toolbelt library only applies its own data dir when `NATSServerOptions == nil`, and we pass our own options, so `StoreDir` stayed empty.

Every branch environment (main + every PR preview) runs as a **separate systemd service on the same host** with no `PrivateTmp`, so they all share `/tmp/jetstream`. JetStream takes an **exclusive lock** on its store dir → the 2nd+ instance comes up with broken/locked JetStream → KV `Get/Put/Watch` fail intermittently → live updates stop. `/tmp` cleanup/reboots also wipe state. That's why a single localhost instance is always fine while co-located prod instances are flaky.

## What

- **Core fix:** new `-nats-store` flag (default `data/nats`, mirroring `-dbp`/`-image-path`), threaded into `setupRoutes` and set explicitly as the NATS `StoreDir`; resolved path is logged at startup.
- **Startup safety:** pre-create + `CheckWritableDirectory` the store dir; on failure degrade with a dedicated readiness reason instead of silently falling back to `/tmp`.
- **Deploy:** each environment gets its own persistent `…/$SAFE_NAME/nats` dir (systemd template + `deploy.sh`), created/chowned and never cloned from main.
- **TTL alignment:** `events` + `billettholder` KV bucket TTL `1h → 24h` to match the `connections` cookie lifetime, so an idle-but-open page keeps its state.

## Relationship to #387

Branched from #387, so it carries that PR's cookie-ordering + KV purge/corrupt recovery fix (which #387 already contains beyond its "logging" title). **This PR supersedes #387.** A full audit confirmed every long-running SSE stream follows the canonical pattern; the remaining `NewSSE`-before-session sites are stateless handlers that never touch the cookie/KV, so they need no change.

## Verification

- `templ generate` clean, `gofmt` clean, full build OK, **all tests pass** (`go test ./...`).
- Ran the binary with `-nats-store /tmp/conorg-storetest`: startup log showed the configured path, JetStream created its store there, and `/tmp/jetstream` was **not** created.
- Ran **two co-located instances** with different store dirs simultaneously → both reached `readyz: 200` with independent stores, proving the isolation that fixes the multi-machine collision.

## Follow-up (not in this PR)

The session cookie secret is the hardcoded `[]byte("session-secret")` (`router.go`). Works, but a weak signing key — worth moving to env later.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://390-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->