### PR TITLE
Updated room id parser to not accept zero values

### DIFF
--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -123,7 +123,8 @@ func updateRoomInRelationEventPuljeWithAudit(ctx context.Context, db *sql.DB, lo
 
 	// convert roomID from string to sql.NullInt64
 	var roomID sql.NullInt64
-	if parsedRoomID, err := strconv.ParseInt(roomIDstring, 10, 64); err == nil {
+	parsedRoomID, err := strconv.ParseInt(roomIDstring, 10, 64)
+	if err == nil && parsedRoomID > 0 {
 		roomID = sql.NullInt64{
 			Int64: parsedRoomID,
 			Valid: true,


### PR DESCRIPTION
This PR fixes the bug where zero values are allowed resulting in sql errors where the database is trying to get a non indexable entry

This resolves #393 

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://394-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->