### PR TITLE
Redirect already logged in users when visiting login route

### DIFF
--- a/pages/login/login.go
+++ b/pages/login/login.go
@@ -22,13 +22,27 @@ func SetupAuthRoute(router chi.Router, db *sql.DB, logger *slog.Logger) error {
 	router.Route("/auth", func(authRouter chi.Router) {
 		authRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			var ctx = r.Context()
-			if err := layouts.Base(
-				"Innlogging til Regncon 2025!",
-				userctx.GetUserRequestInfo(ctx),
-				loginForm(),
-			).Render(ctx, w); err != nil {
-				logger.Error(fmt.Errorf("failed to render login page: %w", err).Error())
+			userToken, _ := authctx.GetUserTokenFromContext(r.Context())
+
+			if userToken != nil {
+				if err := layouts.Base(
+					"Velkomen tilbake til Regncon 2025!",
+					userctx.GetUserRequestInfo(ctx),
+					alreadyLogedIn(),
+				).Render(ctx, w); err != nil {
+					logger.Error(fmt.Errorf("failed to render already loged in page: %w", err).Error())
+				}
+			} else {
+				if err := layouts.Base(
+					"Innlogging til Regncon 2025!",
+					userctx.GetUserRequestInfo(ctx),
+					loginForm(),
+				).Render(ctx, w); err != nil {
+					logger.Error(fmt.Errorf("failed to render login page: %w", err).Error())
+				}
+
 			}
+
 		})
 
 		authRouter.Group(func(protectedRoute chi.Router) {

--- a/pages/login/login.templ
+++ b/pages/login/login.templ
@@ -1,5 +1,45 @@
 package login
 
+templ alreadyLogedIn() {
+	<style>
+    .already-logedin-wrapper {
+        display: flex;
+        flex-flow: column nowrap;
+        width: fit-content;
+        margin: auto;
+        margin-top: var(--responsive-top-of-page-spacing);
+        padding: ;
+        gap: var(--spacing-1x);
+
+        h1 {
+            text-align: center;
+        }
+    }
+    </style>
+	<div class="already-logedin-wrapper page-content-container">
+		<h1>Velkomen tilbake!</h1>
+		<p>Det ser ut til at du allereie er innlogga og du treng ikkje logge inn på nytt. </p>
+		<p>Du vert sendt vidare til framsida om <span id="countdown">5</span> sekund.</p>
+		<p>Om vidaresendinga ikkje fungerer, kan du bruke denna lenkja til <a href="/">framsida</a></p>
+	</div>
+	<script>
+        let remaining = 5
+        const countdown = document.getElementById('countdown')
+
+        const interval = setInterval(() => {
+            remaining--
+
+            if (remaining <= 0) {
+                clearInterval(interval)
+                window.location.replace('/')
+                return
+            }
+
+            countdown.textContent = remaining
+        }, 1000)
+    </script>
+}
+
 templ loginForm() {
 	<script src="https://descopecdn.com/npm/@descope/web-component@3.21.0/dist/index.js"></script>
 	<script src="https://descopecdn.com/npm/@descope/web-js-sdk@1.16.0/dist/index.umd.js"></script>


### PR DESCRIPTION
# Summary
La til conditional check i `/auth` route for brukere som allerede er logget inn, her kan enten `login-page` eller `already-logedin-page` vises basert på om descope token eksiterer. 

- For brukere som allerede er logget inn vill de bli møtt med en side som forklarer at de allerede er logget inn og kan gå tilbake til hovedsiden for å lese innholdet. 
- For brukere som ikke er logget inn vill de kunne se descope innlogging som vanling

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://420-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->