### PR TITLE
Only show my festival schedule when program is published

### DIFF
--- a/components/profile/my_program.templ
+++ b/components/profile/my_program.templ
@@ -2,6 +2,7 @@ package profilecomponent
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -29,18 +30,55 @@ type UserProgramPulje struct {
 	Interests []UserInterest
 }
 
+func getProgramPublished(db *sql.DB) (bool, error) {
+	const query = `
+		SELECT is_published
+		FROM program_publishing_state
+		WHERE id = 1
+	`
+
+	var isPublished int
+	if err := db.QueryRow(query).Scan(&isPublished); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("query program publishing state: %w", err)
+	}
+
+	return isPublished == 1, nil
+}
+
 templ MyProgram(userInfo requestctx.UserRequestInfo, selectedBillettholderID int, db *sql.DB, logger *slog.Logger, eventImageDir *string) {
-	{{ logger = logger.With("component", "profile_program") }}
-	{{ events, err := GetAllEventsForUser(userInfo, selectedBillettholderID, db, logger) }}
-	{{ interests, interestErr := getAllInterestsForUser(userInfo, selectedBillettholderID, db, logger) }}
-	{{ puljeRows, puljeErr := puljerService.GetAllPuljer(db) }}
 	{{
+		logger = logger.With("component", "profile_program")
+		events, err := GetAllEventsForUser(userInfo, selectedBillettholderID, db, logger)
+		interests, interestErr := getAllInterestsForUser(userInfo, selectedBillettholderID, db, logger)
+		puljeRows, puljeErr := puljerService.GetAllPuljer(db)
+		isPublished, publishErr := getProgramPublished(db)
+
+		var hasError bool = false
+		if err != nil {
+			logger.Error(err.Error(), "user_id", userInfo.Id)
+			hasError = true
+		}
+		if interestErr != nil {
+			logger.Error(interestErr.Error(), "user_id", userInfo.Id)
+			hasError = true
+		}
+		if puljeErr != nil {
+			logger.Error(puljeErr.Error(), "user_id", userInfo.Id)
+			hasError = true
+		}
+		if publishErr != nil {
+			logger.Error(publishErr.Error(), "user_id", userInfo.Id)
+			hasError = true
+		}
+
 		puljer := make([]UserProgramPulje, len(puljeRows))
 		for i, pulje := range puljeRows {
 			puljer[i].Pulje = pulje
 		}
-	}}
-	{{
+
 		for i := range puljer {
 
 			for _, event := range events {
@@ -82,40 +120,30 @@ templ MyProgram(userInfo requestctx.UserRequestInfo, selectedBillettholderID int
 		<h2 class="surface-pane-title">
 			Mitt festivalprogram
 		</h2>
-		if err != nil || interestErr != nil || puljeErr != nil {
-			{{
-					if err != nil {
-						logger.Error(err.Error(), "user_id", userInfo.Id)
-					}
-					if interestErr != nil {
-						logger.Error(interestErr.Error(), "user_id", userInfo.Id)
-					}
-					if puljeErr != nil {
-						logger.Error(puljeErr.Error(), "user_id", userInfo.Id)
-					}
-			}}
+		if hasError {
 			<div style="padding: var(--spacing-4x); color: var(--color-error); background-color: var(--bg-error-light); border-radius: var(--border-radius-2x);">
 				<p>Vi klarte ikke å laste hele festivalprogrammet ditt akkurat nå.</p>
 				<p>Prøv igjen om litt.</p>
 			</div>
 		} else {
 			<section class="program-pulje-list">
-				for _, pulje := range puljer {
-					<div class="program-pulje-container">
-						<h3 class="program-pulje">
-							{ pulje.Pulje.Name }
-							<span class="program-pulje-time">({ pulje.Pulje.TimeRange() })</span>
-						</h3>
-						if len(pulje.Events) > 0 {
-							for _, event := range pulje.Events {
-								{{ imageCardUrl := eventimage.GetEventImageUrl(event.EventID, "card", eventImageDir) }}
-								{{ imageBannerUrl := eventimage.GetEventImageUrl(event.EventID, "banner", eventImageDir) }}
-								@event_components.ProgramPuljeEvent(event.EventID, imageCardUrl, imageBannerUrl, event.Title, event.Intro, event.EventType, event.IsGM)
+				if isPublished {
+					for _, pulje := range puljer {
+						<div class="program-pulje-container">
+							<h3 class="program-pulje">
+								{ pulje.Pulje.Name }
+								<span class="program-pulje-time">({ pulje.Pulje.TimeRange() })</span>
+							</h3>
+							if len(pulje.Events) > 0 {
+								for _, event := range pulje.Events {
+									{{ imageCardUrl := eventimage.GetEventImageUrl(event.EventID, "card", eventImageDir) }}
+									{{ imageBannerUrl := eventimage.GetEventImageUrl(event.EventID, "banner", eventImageDir) }}
+									@event_components.ProgramPuljeEvent(event.EventID, imageCardUrl, imageBannerUrl, event.Title, event.Intro, event.EventType, event.IsGM)
+								}
 							}
-						}
-						if len(pulje.Events) == 0 && len(pulje.Interests) > 0 {
-							{{ interestList := make([]event_components.Interest, len(pulje.Interests)) }}
-							{{
+							if len(pulje.Events) == 0 && len(pulje.Interests) > 0 {
+								{{ interestList := make([]event_components.Interest, len(pulje.Interests)) }}
+								{{
 									for i, interest := range pulje.Interests {
 										interestList[i] = event_components.Interest{
 											EventID:       interest.EventID,
@@ -123,12 +151,21 @@ templ MyProgram(userInfo requestctx.UserRequestInfo, selectedBillettholderID int
 											InterestLevel: interest.InterestLevel,
 										}
 									}
-							}}
-							@event_components.ProgramPuljeInterests(interestList)
-						}
-						if len(pulje.Events) == 0 && len(pulje.Interests) == 0 {
-							@event_components.ProgramPuljeNoEvents(pulje.Pulje.ID)
-						}
+								}}
+								@event_components.ProgramPuljeInterests(interestList)
+							}
+							if len(pulje.Events) == 0 && len(pulje.Interests) == 0 {
+								@event_components.ProgramPuljeNoEvents(pulje.Pulje.ID)
+							}
+						</div>
+					}
+				} else {
+					<div class="program-pulje-container">
+						<h3 class="program-pulje" style="text-align: center;">Programmet for Regncon er ikkje publisert enno</h3>
+						<p>
+							Vi arbeider framleis med planlegginga og vil leggje ut programmet så snart det er klart.
+							Følg med på nettsida for oppdateringar og nyheiter.
+						</p>
 					</div>
 				}
 			</section>

--- a/components/profile/my_program_render_test.go
+++ b/components/profile/my_program_render_test.go
@@ -110,3 +110,37 @@ func TestMyProgram_WhenGMEventIsInNotCompletedPulje_RendersGMEventOverInterests(
 		t.Fatalf("expected rendered profile program to hide %q\nactual text: %s", hiddenVisibleText, actualText)
 	}
 }
+
+func TestMyProgram_WhenProgramIsNotReady_HidesPlayerResult(t *testing.T) {
+	bdd.Behavior(t, bdd.BDD{
+		Given: "Given that the festival program is not published",
+		When:  "When Mitt festivalprogram is rendered.",
+		Then:  "Then the visible HTML hides what the user is playing and presents information text.",
+	})
+
+	// Given
+	expectedVisibleText := "Completed Player Result"
+	hiddenVisibleText := "Completed Wish Hidden By Result"
+	expectedStatusText := "Programmet for Regncon er ikkje publisert enno"
+
+	db, logger := createProfileProgramTestDB(t)
+	userInfo, billettholderID := seedProfileProgramUser(t, db)
+	insertProfileProgram(t, db, false)
+	insertProfileProgramPulje(t, db, models.PuljeFredagKveld, models.PuljeStatusCompleted)
+	insertProfileProgramPublishedEvent(t, db, "completed-player-result", expectedVisibleText)
+	insertProfileProgramPublishedEvent(t, db, "completed-wish-event", hiddenVisibleText)
+	insertProfileProgramPlayer(t, db, "completed-player-result", models.PuljeFredagKveld, billettholderID, models.EventPlayerRolePlayer)
+	insertProfileProgramInterest(t, db, "completed-wish-event", models.PuljeFredagKveld, billettholderID, models.InterestLevelHigh)
+
+	// When
+	doc := templtest.Render(t, MyProgram(userInfo, billettholderID, db, logger, nil))
+	actualText := profileProgramVisibleText(doc)
+
+	// Then
+	if !strings.Contains(actualText, expectedStatusText) {
+		t.Fatalf("expected rendered profile program to contain %q\nactual text: %s", expectedVisibleText, actualText)
+	}
+	if strings.Contains(actualText, expectedVisibleText) {
+		t.Fatalf("expected rendered profile program to contain %q\nactual text: %s", expectedVisibleText, actualText)
+	}
+}

--- a/components/profile/my_program_render_test.go
+++ b/components/profile/my_program_render_test.go
@@ -22,6 +22,7 @@ func TestMyProgram_WhenPuljeIsNotCompleted_RendersInterestsAndHidesPlayerResult(
 
 	db, logger := createProfileProgramTestDB(t)
 	userInfo, billettholderID := seedProfileProgramUser(t, db)
+	insertProfileProgram(t, db, true)
 	insertProfileProgramPulje(t, db, models.PuljeFredagKveld, models.PuljeStatusOpen)
 	insertProfileProgramPublishedEvent(t, db, "hidden-player-result", hiddenVisibleText)
 	insertProfileProgramPublishedEvent(t, db, "visible-wish-event", expectedVisibleText)
@@ -57,6 +58,7 @@ func TestMyProgram_WhenPuljeIsCompleted_RendersPlayerResult(t *testing.T) {
 
 	db, logger := createProfileProgramTestDB(t)
 	userInfo, billettholderID := seedProfileProgramUser(t, db)
+	insertProfileProgram(t, db, true)
 	insertProfileProgramPulje(t, db, models.PuljeFredagKveld, models.PuljeStatusCompleted)
 	insertProfileProgramPublishedEvent(t, db, "completed-player-result", expectedVisibleText)
 	insertProfileProgramPublishedEvent(t, db, "completed-wish-event", hiddenVisibleText)
@@ -89,6 +91,7 @@ func TestMyProgram_WhenGMEventIsInNotCompletedPulje_RendersGMEventOverInterests(
 
 	db, logger := createProfileProgramTestDB(t)
 	userInfo, billettholderID := seedProfileProgramUser(t, db)
+	insertProfileProgram(t, db, true)
 	insertProfileProgramPulje(t, db, models.PuljeFredagKveld, models.PuljeStatusLocked)
 	insertProfileProgramPublishedEvent(t, db, "locked-gm-event", expectedVisibleText)
 	insertProfileProgramPublishedEvent(t, db, "locked-wish-event", hiddenVisibleText)

--- a/components/profile/my_program_test_helpers_test.go
+++ b/components/profile/my_program_test_helpers_test.go
@@ -96,6 +96,21 @@ func insertProfileProgramPulje(t *testing.T, db *sql.DB, puljeID models.Pulje, s
 	`, puljeID, "Fredag kveld", status, "2026-10-09T18:00:00Z", "2026-10-09T23:00:00Z")
 }
 
+func insertProfileProgram(t *testing.T, db *sql.DB, programPublished bool) {
+	t.Helper()
+
+	isPublished := 0
+	if programPublished {
+		isPublished = 1
+	}
+
+	mustExecProfileProgramTest(t, db, `
+		INSERT INTO program_publishing_state(id, is_published)
+		VALUES (1, ?)
+		ON CONFLICT(id) DO UPDATE SET is_published = excluded.is_published
+	`, isPublished)
+}
+
 func insertProfileProgramPublishedEvent(t *testing.T, db *sql.DB, eventID string, title string) {
 	t.Helper()
 


### PR DESCRIPTION
# Summary
Dette er en liten endring til `Mitt festival` seksjonen på profil siden for å gjemme vekk interressevelger og tildelte eventer når festivalprogram ikke er publisert

I tillegg har eksisterende tester for `my program` blitt oppdatert, dette påvirker følgende tester:
- TestMyProgram_WhenGMEventIsInNotCompletedPulje_RendersGMEventOverInterests
- TestMyProgram_WhenPuljeIsCompleted_RendersPlayerResult
- TestMyProgram_WhenPuljeIsNotCompleted_RendersInterestsAndHidesPlayerResult

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://421-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->