### PR TITLE
Removed status section for event cards on home page

### DIFF
--- a/components/event_card.templ
+++ b/components/event_card.templ
@@ -2,8 +2,8 @@ package components
 
 import (
 	"fmt"
-	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/components/icons"
+	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/eventimage"
 )
 
@@ -21,36 +21,6 @@ templ EventCard(eventCard models.EventCardModel, eventImageDir *string, showStat
 		}
 		class="event-card-container"
 	>
-		if showStatus {
-			<div class="event-card-status-tag">
-				if eventCard.IsPublished {
-					<div style="color:var(--color-success);display: flex;align-items: center; gap: 0.5rem;">
-						@icons.Icon(icons.ProgressComplete, icons.Size20)
-						<span>Publisert i pulje</span>
-					</div>
-				} else if eventCard.Status == models.EventStatusDraft {
-					<div style="color:var(--color-soft-text);display: flex;align-items: center; gap: 0.5rem;">
-						@icons.Icon(icons.Progress25, icons.Size20)
-						<span>{ eventCard.Status.Label() }</span>
-					</div>
-				} else if eventCard.Status == models.EventStatusSubmitted {
-					<div style="color:var(--color-soft-text);display: flex;align-items: center; gap: 0.5rem;">
-						@icons.Icon(icons.Progress50, icons.Size20)
-						<span>{ eventCard.Status.Label() }</span>
-					</div>
-				} else if eventCard.Status == models.EventStatusApproved {
-					<div style="color:var(--color-warning);display: flex;align-items: center; gap: 0.5rem;">
-						@icons.Icon(icons.Progress75, icons.Size20)
-						<span>{ eventCard.Status.Label() }</span>
-					</div>
-				} else if eventCard.Status == models.EventStatusArchived {
-					<div style="color:var(--color-error);display: flex;align-items: center; gap: 0.5rem;">
-						@icons.Icon(icons.ProgressRejected, icons.Size20)
-						<span>{ eventCard.Status.Label() }</span>
-					</div>
-				}
-			</div>
-		}
 		<img
 			src={ imageUrl }
 			alt="Bilde for arrangement"


### PR DESCRIPTION
# Summary
Fjernet event status fra event kort som vises på landingssiden fordi kun `approved` eventer blir vist der.

## Notes
Jeg valgte å ikke fjerne `isAdmin` bool arg fra `EventCard` siden det medfører endret funksjonalitet for følgende filer:
- pages/root/event_list.templ
- pages/root/root_index.templ
- pages/root/root_page.templ
- pages/root/root.go

og alle test filene
- pages/root/root_page_program_published_test.go
- pages/root/root_page_program_unpublished_test.go
- pages/root/root_page_test.go

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://422-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->