### PR TITLE
feat(puljefordeling): pinned-seat solver support + fairness replay

### DIFF
--- a/service/puljefordeling/solver/solver.go
+++ b/service/puljefordeling/solver/solver.go
@@ -439,3 +439,59 @@ func bandBase(score model.Score, satisfied bool) int {
 		return bandLitt
 	}
 }
+
+// ApplyActual seeds the fairness state from a known persisted assignment for a slot
+// without running the solver. It advances the slot index (so subsequent seeds stay
+// aligned), echoes the assignment into the returned result, and updates
+// seated/satisfied/misses exactly as a solved slot would. Used to replay frozen
+// puljer so later puljer are seeded from what actually happened.
+func (s *State) ApplyActual(slot model.Slot, players []model.Player, assignments map[string][]string) model.SlotResult {
+	currentIndex := s.slotIndex
+	seed := int64(s.year)*1000 + int64(currentIndex)
+	s.slotIndex++
+
+	// Copy the assignment so sorting/appends never mutate the caller's map.
+	clone := make(map[string][]string, len(assignments))
+	for evID, pids := range assignments {
+		clone[evID] = append([]string(nil), pids...)
+	}
+
+	result := model.SlotResult{
+		SlotID:      slot.ID,
+		Assignments: clone,
+		Seed:        seed,
+	}
+
+	dmingHere := make(map[string]bool)
+	for _, ev := range slot.Events {
+		if ev.DMID != "" {
+			dmingHere[ev.DMID] = true
+		}
+	}
+
+	interested := make([]model.Player, 0, len(players))
+	for _, p := range players {
+		if dmingHere[p.ID] {
+			continue
+		}
+		if len(p.Prefs[slot.ID]) > 0 {
+			interested = append(interested, p)
+		}
+	}
+
+	playerByID := make(map[string]model.Player, len(players))
+	for _, p := range players {
+		playerByID[p.ID] = p
+	}
+
+	s.applyResult(&result, slot.ID, interested, playerByID, result.Assignments)
+
+	for _, ev := range slot.Events {
+		if len(result.Assignments[ev.ID]) < minViablePlayers {
+			result.UndersubscribedEvents = append(result.UndersubscribedEvents, ev.ID)
+		}
+	}
+
+	sortSlotResult(&result)
+	return result
+}

--- a/service/puljefordeling/solver/solver.go
+++ b/service/puljefordeling/solver/solver.go
@@ -157,33 +157,39 @@ func (s *State) SolveSlotFixed(slot model.Slot, players []model.Player, fixed ma
 	}
 
 	// Players DMing in this slot are unavailable as players.
-	dmingHere := make(map[string]bool)
+	dmingHere := make(map[string]struct{})
 	for _, ev := range slot.Events {
 		if ev.DMID != "" {
-			dmingHere[ev.DMID] = true
+			dmingHere[ev.DMID] = struct{}{}
 		}
 	}
 
 	// Validate pins: keep only those whose event is in this slot and whose player
 	// is not DMing here.
-	eventInSlot := make(map[string]bool, len(slot.Events))
+	eventInSlot := make(map[string]struct{}, len(slot.Events))
 	for _, ev := range slot.Events {
-		eventInSlot[ev.ID] = true
+		eventInSlot[ev.ID] = struct{}{}
 	}
 	pinnedByEvent := make(map[string][]string)
-	pinned := make(map[string]bool)
+	pinned := make(map[string]struct{})
 	for pid, evID := range fixed {
-		if !eventInSlot[evID] || dmingHere[pid] {
+		if _, ok := eventInSlot[evID]; !ok {
+			continue
+		}
+		if _, ok := dmingHere[pid]; ok {
 			continue
 		}
 		pinnedByEvent[evID] = append(pinnedByEvent[evID], pid)
-		pinned[pid] = true
+		pinned[pid] = struct{}{}
 	}
 
 	// Free pool: interested players who are neither DMing here nor pinned.
 	interested := make([]model.Player, 0, len(players))
 	for _, p := range players {
-		if dmingHere[p.ID] || pinned[p.ID] {
+		if _, ok := dmingHere[p.ID]; ok {
+			continue
+		}
+		if _, ok := pinned[p.ID]; ok {
 			continue
 		}
 		if len(p.Prefs[slot.ID]) > 0 {
@@ -211,7 +217,7 @@ func (s *State) SolveSlotFixed(slot model.Slot, players []model.Player, fixed ma
 
 	// Solve the free pool over the reduced-capacity events.
 	assignments := make(map[string][]string)
-	var moved map[string]bool
+	var moved map[string]struct{}
 	if len(interested) > 0 {
 		rng := rand.New(rand.NewPCG(uint64(seed), 0)) //nolint:gosec
 		rng.Shuffle(len(interested), func(i, j int) {
@@ -239,7 +245,7 @@ func (s *State) SolveSlotFixed(slot model.Slot, players []model.Player, fixed ma
 	// Players bumped off a higher-scoring event by a residual augmentation and
 	// still holding a seat.
 	for pid := range moved {
-		if assigned[pid] {
+		if _, ok := assigned[pid]; ok {
 			result.MovedPlayers = append(result.MovedPlayers, pid)
 		}
 	}
@@ -258,8 +264,8 @@ func (s *State) applyResult(
 	interested []model.Player,
 	playerByID map[string]model.Player,
 	assignments map[string][]string,
-) map[string]bool {
-	assigned := make(map[string]bool)
+) map[string]struct{} {
+	assigned := make(map[string]struct{})
 	for evID, playerIDs := range assignments {
 		for _, pid := range playerIDs {
 			score := playerByID[pid].Prefs[slotID][evID]
@@ -269,7 +275,7 @@ func (s *State) applyResult(
 				s.satisfied[pid] = true
 				result.NewlySatisfied = append(result.NewlySatisfied, pid)
 			}
-			assigned[pid] = true
+			assigned[pid] = struct{}{}
 		}
 	}
 
@@ -286,7 +292,7 @@ func (s *State) applyResult(
 
 	// Unassigned: interested (free-pool) players who got no seat.
 	for _, p := range interested {
-		if !assigned[p.ID] {
+		if _, ok := assigned[p.ID]; !ok {
 			result.Unassigned = append(result.Unassigned, p.ID)
 		}
 	}
@@ -323,7 +329,7 @@ func (s *State) runMCMF(
 	slotID string,
 	events []model.Event,
 	players []model.Player,
-) (map[string][]string, map[string]bool) {
+) (map[string][]string, map[string]struct{}) {
 	assignments := make(map[string][]string)
 	if len(events) == 0 {
 		return assignments, nil
@@ -376,14 +382,14 @@ func (s *State) runMCMF(
 	// A reduced forward edge ran player→event (forward at fe, its reverse at
 	// fe^1 runs event→player, so its .to is the player node). Flow pushed back
 	// along it means that player was bumped off the event.
-	moved := make(map[string]bool)
+	moved := make(map[string]struct{})
 	for _, fe := range reduced {
 		playerNode := g.edges[fe^1].to
 		eventNode := g.edges[fe].to
 		if playerNode < 1 || playerNode > P || eventNode < P+1 || eventNode > P+E {
 			continue
 		}
-		moved[players[playerNode-1].ID] = true
+		moved[players[playerNode-1].ID] = struct{}{}
 	}
 
 	for i, p := range players {
@@ -462,16 +468,16 @@ func (s *State) ApplyActual(slot model.Slot, players []model.Player, assignments
 		Seed:        seed,
 	}
 
-	dmingHere := make(map[string]bool)
+	dmingHere := make(map[string]struct{})
 	for _, ev := range slot.Events {
 		if ev.DMID != "" {
-			dmingHere[ev.DMID] = true
+			dmingHere[ev.DMID] = struct{}{}
 		}
 	}
 
 	interested := make([]model.Player, 0, len(players))
 	for _, p := range players {
-		if dmingHere[p.ID] {
+		if _, ok := dmingHere[p.ID]; ok {
 			continue
 		}
 		if len(p.Prefs[slot.ID]) > 0 {

--- a/service/puljefordeling/solver/solver.go
+++ b/service/puljefordeling/solver/solver.go
@@ -132,19 +132,20 @@ func (s *State) IsDM(playerID string) bool {
 	return s.isDM[playerID]
 }
 
-// SolveSlot assigns players to events for one slot, updates the fairness
-// state, and returns the result.
-//
-// Players who are DMing any event in this slot are excluded from the player
-// pool — they cannot also be assigned as participants in the same slot.
-//
-// Participation is priced (see participationBonus): a chair is filled only when
-// doing so is worth the welfare it costs, so an interested player may be left
-// unseated rather than dragged off a strong preference to fill a seat.
-//
-// Events whose minViablePlayers threshold is not met are NOT cancelled — they
-// are reported in UndersubscribedEvents for the organiser to review manually.
+// SolveSlot assigns players to events for one slot with no pinned placements.
 func (s *State) SolveSlot(slot model.Slot, players []model.Player) model.SlotResult {
+	return s.SolveSlotFixed(slot, players, nil)
+}
+
+// SolveSlotFixed assigns players to events for one slot, honoring pinned manual
+// placements (fixed maps playerID → eventID), updates the fairness state, and
+// returns the result.
+//
+// A pinned player is reserved into their event (consuming a seat and reducing the
+// event's effective capacity) and is removed from the free assignment pool. Pins
+// are honored even when the player expressed no interest in that event. Players
+// DMing any event in this slot are excluded from the player pool.
+func (s *State) SolveSlotFixed(slot model.Slot, players []model.Player, fixed map[string]string) model.SlotResult {
 	currentIndex := s.slotIndex
 	seed := int64(s.year)*1000 + int64(currentIndex)
 	s.slotIndex++
@@ -163,49 +164,105 @@ func (s *State) SolveSlot(slot model.Slot, players []model.Player) model.SlotRes
 		}
 	}
 
-	// Only consider players who expressed interest and are not DMing here.
+	// Validate pins: keep only those whose event is in this slot and whose player
+	// is not DMing here.
+	eventInSlot := make(map[string]bool, len(slot.Events))
+	for _, ev := range slot.Events {
+		eventInSlot[ev.ID] = true
+	}
+	pinnedByEvent := make(map[string][]string)
+	pinned := make(map[string]bool)
+	for pid, evID := range fixed {
+		if !eventInSlot[evID] || dmingHere[pid] {
+			continue
+		}
+		pinnedByEvent[evID] = append(pinnedByEvent[evID], pid)
+		pinned[pid] = true
+	}
+
+	// Free pool: interested players who are neither DMing here nor pinned.
 	interested := make([]model.Player, 0, len(players))
 	for _, p := range players {
-		if dmingHere[p.ID] {
+		if dmingHere[p.ID] || pinned[p.ID] {
 			continue
 		}
 		if len(p.Prefs[slot.ID]) > 0 {
 			interested = append(interested, p)
 		}
 	}
-	if len(interested) == 0 {
-		return result
-	}
 
-	// Shuffle players before building the graph so that equal-weight ties are
-	// broken randomly but reproducibly.
-	rng := rand.New(rand.NewPCG(uint64(seed), 0)) //nolint:gosec
-	rng.Shuffle(len(interested), func(i, j int) {
-		interested[i], interested[j] = interested[j], interested[i]
-	})
-
-	// Index players by ID so score lookups during the totals pass are O(1)
-	// rather than a linear scan per assignment.
-	playerByID := make(map[string]model.Player, len(interested))
-	for _, p := range interested {
+	// Index ALL players so pinned players' prefs are available for satisfaction.
+	playerByID := make(map[string]model.Player, len(players))
+	for _, p := range players {
 		playerByID[p.ID] = p
 	}
 
-	assignments, moved := s.runMCMF(slot.ID, slot.Events, interested)
+	// Reduce each event's capacity by the number of players pinned into it.
+	events := make([]model.Event, len(slot.Events))
+	copy(events, slot.Events)
+	for i := range events {
+		if n := len(pinnedByEvent[events[i].ID]); n > 0 {
+			events[i].Capacity -= n
+			if events[i].Capacity < 0 {
+				events[i].Capacity = 0
+			}
+		}
+	}
+
+	// Solve the free pool over the reduced-capacity events.
+	assignments := make(map[string][]string)
+	var moved map[string]bool
+	if len(interested) > 0 {
+		rng := rand.New(rand.NewPCG(uint64(seed), 0)) //nolint:gosec
+		rng.Shuffle(len(interested), func(i, j int) {
+			interested[i], interested[j] = interested[j], interested[i]
+		})
+		assignments, moved = s.runMCMF(slot.ID, events, interested)
+	}
+
+	// Merge pinned placements into the assignment.
+	for evID, pids := range pinnedByEvent {
+		assignments[evID] = append(assignments[evID], pids...)
+	}
 	result.Assignments = assignments
 
-	// Flag events with fewer than minViablePlayers for human review.
+	// Flag events with fewer than minViablePlayers (against final counts).
 	for _, ev := range slot.Events {
 		if len(assignments[ev.ID]) < minViablePlayers {
 			result.UndersubscribedEvents = append(result.UndersubscribedEvents, ev.ID)
 		}
 	}
 
-	// Update satisfaction/seated state and collect totals.
-	assigned := make(map[string]bool, len(interested))
+	// Update fairness/totals/misses/unassigned; returns the seated set.
+	assigned := s.applyResult(&result, slot.ID, interested, playerByID, assignments)
+
+	// Players bumped off a higher-scoring event by a residual augmentation and
+	// still holding a seat.
+	for pid := range moved {
+		if assigned[pid] {
+			result.MovedPlayers = append(result.MovedPlayers, pid)
+		}
+	}
+
+	sortSlotResult(&result)
+	return result
+}
+
+// applyResult updates fairness state (seated/satisfied/misses) from a final
+// assignment, fills the result's per-assignment fields (TotalScore, NewlySatisfied,
+// Unassigned), and returns the set of seated player IDs. assignments is
+// eventID → []playerID. Scores for players absent from playerByID are treated as 0.
+func (s *State) applyResult(
+	result *model.SlotResult,
+	slotID string,
+	interested []model.Player,
+	playerByID map[string]model.Player,
+	assignments map[string][]string,
+) map[string]bool {
+	assigned := make(map[string]bool)
 	for evID, playerIDs := range assignments {
 		for _, pid := range playerIDs {
-			score := playerByID[pid].Prefs[slot.ID][evID]
+			score := playerByID[pid].Prefs[slotID][evID]
 			result.TotalScore += int(score)
 			s.seated[pid] = true
 			if score == model.MaxScore && !s.satisfied[pid] {
@@ -216,37 +273,29 @@ func (s *State) SolveSlot(slot model.Slot, players []model.Player) model.SlotRes
 		}
 	}
 
-	// Players bumped off a higher-scoring event by a residual-edge augmentation
-	// and re-seated elsewhere to improve the global result. Restricted to players
-	// who still hold a seat, so it always describes a relocation, never a player
-	// who merely lost contention without ever being tentatively seated.
-	for pid := range moved {
-		if assigned[pid] {
-			result.MovedPlayers = append(result.MovedPlayers, pid)
-		}
-	}
-
-	// Record a "miss" for every still-unsatisfied player who wanted a top
-	// choice this slot but did not get one — this drives the scarcity bonus in
-	// future slots. It is backward-looking on the locked result, so it cannot
-	// be gamed by how a player declares future interests.
+	// Record a miss for every still-unsatisfied free-pool player who wanted a top
+	// choice this slot but did not get one.
 	for _, p := range interested {
 		if s.satisfied[p.ID] {
 			continue
 		}
-		if wantedTopChoice(p, slot.ID) {
+		if wantedTopChoice(p, slotID) {
 			s.misses[p.ID]++
 		}
 	}
 
-	// Collect unassigned players (had interest but no seat).
+	// Unassigned: interested (free-pool) players who got no seat.
 	for _, p := range interested {
 		if !assigned[p.ID] {
 			result.Unassigned = append(result.Unassigned, p.ID)
 		}
 	}
 
-	// Sort all output slices for deterministic results.
+	return assigned
+}
+
+// sortSlotResult sorts all output slices for deterministic results.
+func sortSlotResult(result *model.SlotResult) {
 	sort.Strings(result.NewlySatisfied)
 	sort.Strings(result.Unassigned)
 	sort.Strings(result.UndersubscribedEvents)
@@ -254,8 +303,6 @@ func (s *State) SolveSlot(slot model.Slot, players []model.Player) model.SlotRes
 	for evID := range result.Assignments {
 		sort.Strings(result.Assignments[evID])
 	}
-
-	return result
 }
 
 // wantedTopChoice reports whether the player rated any event in this slot as a

--- a/service/puljefordeling/solver/solver_test.go
+++ b/service/puljefordeling/solver/solver_test.go
@@ -491,3 +491,62 @@ func TestSolveSlot_DMPriorityBeatsRegularPlayer(t *testing.T) {
 		t.Errorf("DM should beat regular player for the seat, got %v", assigned(result, "A"))
 	}
 }
+
+func TestSolveSlotFixed_PinnedSeatHonoredWithoutPreference(t *testing.T) {
+	// "kid" has NO preference for A, but is manually pinned there. The pin must be
+	// honored, and the seat must reduce A's effective capacity.
+	sl := slot("s1", event("A", 2))
+	players := []model.Player{
+		player("alice", prefs("s1", map[string]model.Score{"A": 5})),
+		player("bob", prefs("s1", map[string]model.Score{"A": 5})),
+		// "kid" intentionally absent from players: a manual placement with no interest.
+	}
+
+	result := NewState(2026, weekendOf(sl)).SolveSlotFixed(sl, players, map[string]string{"kid": "A"})
+
+	if !slices.Contains(assigned(result, "A"), "kid") {
+		t.Errorf("pinned kid must be seated in A, got %v", assigned(result, "A"))
+	}
+	if len(assigned(result, "A")) != 2 {
+		t.Errorf("A cap 2: pin takes one seat, solver fills one more, want 2 total, got %d", len(assigned(result, "A")))
+	}
+	// Exactly one of alice/bob got the remaining seat; the other is unassigned.
+	if len(result.Unassigned) != 1 {
+		t.Errorf("want 1 unassigned (only 1 free seat after the pin), got %v", result.Unassigned)
+	}
+}
+
+func TestSolveSlotFixed_PinnedSeatCountsAsSeated(t *testing.T) {
+	// A pinned player who got their top choice is satisfied; one with no/low
+	// interest is seated but not satisfied.
+	sl := slot("s1", event("A", 4))
+	players := []model.Player{
+		player("top", prefs("s1", map[string]model.Score{"A": 5})),
+	}
+
+	st := NewState(2026, weekendOf(sl))
+	result := st.SolveSlotFixed(sl, players, map[string]string{"top": "A", "nopref": "A"})
+
+	if !st.IsSatisfied("top") {
+		t.Error("pinned player whose pinned event is their top choice should be satisfied")
+	}
+	if st.IsSatisfied("nopref") {
+		t.Error("pinned player with no top-choice preference must not be satisfied")
+	}
+	if !slices.Contains(result.NewlySatisfied, "top") {
+		t.Errorf("top should be newly satisfied, got %v", result.NewlySatisfied)
+	}
+}
+
+func TestSolveSlot_NilFixedRegression(t *testing.T) {
+	// The 2-arg SolveSlot must behave exactly as before (delegates with nil).
+	sl := slot("s1", event("A", 1))
+	players := []model.Player{
+		player("low", prefs("s1", map[string]model.Score{"A": 3})),
+		player("high", prefs("s1", map[string]model.Score{"A": 5})),
+	}
+	result := NewState(2026, weekendOf(sl)).SolveSlot(sl, players)
+	if !slices.Contains(assigned(result, "A"), "high") {
+		t.Error("high scorer should still win with nil fixed")
+	}
+}

--- a/service/puljefordeling/solver/solver_test.go
+++ b/service/puljefordeling/solver/solver_test.go
@@ -550,3 +550,38 @@ func TestSolveSlot_NilFixedRegression(t *testing.T) {
 		t.Error("high scorer should still win with nil fixed")
 	}
 }
+
+func TestApplyActual_SeedsFairnessFromRealSeats(t *testing.T) {
+	// Replay slot 1 where alice actually got her top choice (A) and bob actually
+	// missed his top choice. Then in slot 2 (same single seat) bob — now carrying a
+	// miss and never satisfied — should beat the already-satisfied alice.
+	sl1 := slot("s1", event("A", 1))
+	sl2 := slot("s2", event("A", 1))
+
+	alice := model.Player{ID: "alice", Name: "alice", Prefs: map[string]map[string]model.Score{
+		"s1": {"A": 5}, "s2": {"A": 5},
+	}}
+	bob := model.Player{ID: "bob", Name: "bob", Prefs: map[string]map[string]model.Score{
+		"s1": {"A": 5}, "s2": {"A": 5},
+	}}
+
+	st := NewState(2026, weekendOf(sl1, sl2))
+
+	// Replay the actual slot-1 result: alice seated in A, bob unseated.
+	r1 := st.ApplyActual(sl1, []model.Player{alice, bob}, map[string][]string{"A": {"alice"}})
+	if !slices.Contains(r1.Assignments["A"], "alice") {
+		t.Fatalf("ApplyActual should echo the actual assignment, got %v", r1.Assignments["A"])
+	}
+	if !st.IsSatisfied("alice") {
+		t.Error("alice got her top choice in the replayed slot → satisfied")
+	}
+	if st.IsSatisfied("bob") {
+		t.Error("bob was not seated → not satisfied")
+	}
+
+	// Now solve slot 2: bob (unsatisfied + a miss) should win over satisfied alice.
+	r2 := st.SolveSlot(sl2, []model.Player{alice, bob})
+	if !slices.Contains(assigned(r2, "A"), "bob") {
+		t.Errorf("bob (missed + unsatisfied) should win slot 2 over satisfied alice, got %v", assigned(r2, "A"))
+	}
+}


### PR DESCRIPTION
As we wish to pin 📌 players to tables as Admin, we will need support in the algorithm to ignore these players and adjust the capacity of the table.

## What's included
- **`SolveSlotFixed`** (`90a095c4`) — pinned-seat support in the solver: solve a slot while honouring already-fixed seat assignments rather than placing everyone from scratch.
- **`ApplyActual`** (`7f301945`) — fairness replay from persisted seats, so previously-committed placements feed back into fairness accounting.
- Accompanying unit tests in `solver/solver_test.go`.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://454-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->