### PR TITLE
feat(puljefordeling): add source column to relation_events_players

### DIFF
--- a/initialize.sql
+++ b/initialize.sql
@@ -153,6 +153,7 @@ CREATE TABLE
         pulje_id TEXT NOT NULL,
         billettholder_id INTEGER NOT NULL,
         role TEXT NOT NULL DEFAULT 'Player' CHECK (role IN ('Player', 'GM')),
+        source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual','solver')),
         inserted_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         PRIMARY KEY (billettholder_id, event_id, pulje_id),
         FOREIGN KEY (billettholder_id) REFERENCES billettholdere (id),

--- a/migrations/20260623120000_add_source_to_relation_events_players.sql
+++ b/migrations/20260623120000_add_source_to_relation_events_players.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE relation_events_players
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual','solver'));
+
+-- +goose Down
+ALTER TABLE relation_events_players DROP COLUMN source;

--- a/schema.sql
+++ b/schema.sql
@@ -70,7 +70,7 @@ CREATE TABLE relation_events_players(
   pulje_id TEXT NOT NULL,
   billettholder_id INTEGER NOT NULL,
   role TEXT NOT NULL DEFAULT 'Player' CHECK(role IN('Player', 'GM')),
-  source TEXT NOT NULL DEFAULT 'manual' CHECK(source IN('manual','solver')),
+  source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual','solver')),
   inserted_at TEXT DEFAULT(strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   PRIMARY KEY(billettholder_id, event_id, pulje_id),
   FOREIGN KEY(billettholder_id) REFERENCES billettholdere(id),

--- a/schema.sql
+++ b/schema.sql
@@ -70,6 +70,7 @@ CREATE TABLE relation_events_players(
   pulje_id TEXT NOT NULL,
   billettholder_id INTEGER NOT NULL,
   role TEXT NOT NULL DEFAULT 'Player' CHECK(role IN('Player', 'GM')),
+  source TEXT NOT NULL DEFAULT 'manual' CHECK(source IN('manual','solver')),
   inserted_at TEXT DEFAULT(strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   PRIMARY KEY(billettholder_id, event_id, pulje_id),
   FOREIGN KEY(billettholder_id) REFERENCES billettholdere(id),

--- a/service/puljefordeling/schema_source_test.go
+++ b/service/puljefordeling/schema_source_test.go
@@ -1,0 +1,38 @@
+package puljefordeling
+
+import (
+	"testing"
+
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func TestRelationEventsPlayersHasSourceColumn(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "test_schema_source")
+
+	rows, err := db.Query(`PRAGMA table_info(relation_events_players)`)
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			ctype      string
+			notnull    int
+			dflt       any
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &primaryKey); err != nil {
+			t.Fatalf("scan column: %v", err)
+		}
+		if name == "source" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("relation_events_players is missing the 'source' column")
+	}
+}

--- a/service/puljefordeling/schema_source_test.go
+++ b/service/puljefordeling/schema_source_test.go
@@ -30,7 +30,16 @@ func TestRelationEventsPlayersHasSourceColumn(t *testing.T) {
 		}
 		if name == "source" {
 			found = true
+			if ctype != "TEXT" {
+				t.Errorf("source column has type %q, want \"TEXT\"", ctype)
+			}
+			if notnull != 1 {
+				t.Errorf("source column notnull = %d, want 1 (NOT NULL)", notnull)
+			}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate columns: %v", err)
 	}
 	if !found {
 		t.Error("relation_events_players is missing the 'source' column")


### PR DESCRIPTION
Splits the DB foundation out of #452 so the schema change can land independently of the puljefordeling UI/persistence work.

```
ALTER TABLE relation_events_players
    ADD COLUMN source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual','solver'));
```

**It is needed to store in DB that we manually placed/pinned someone so the algorithm solver can persist that**

## What's included
- Migration `20260623120000_add_source_to_relation_events_players.sql` adding a `source` column (with CHECK constraint) to `relation_events_players`.
- Mirrored in `schema.sql` and `initialize.sql`.
- `schema_source_test.go` asserts the column exists.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://455-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->