### PR TITLE
feat(formsubmission): export PuljeAssignmentSearch picker for reuse

### DIFF
--- a/components/formsubmission/assignment_search_test.go
+++ b/components/formsubmission/assignment_search_test.go
@@ -1,0 +1,29 @@
+package formsubmission
+
+import (
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+	"github.com/Regncon/conorganizer/testutil/templtest"
+)
+
+func TestPuljeAssignmentSearch_RendersPickerAndButtons(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "test_pulje_assignment_search")
+
+	if _, err := db.Exec(
+		`INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		 VALUES (1, 'Anna', 'A', 0, '', 0, 1)`,
+	); err != nil {
+		t.Fatalf("seed billettholder: %v", err)
+	}
+
+	doc := templtest.Render(t, PuljeAssignmentSearch(db, logger, models.PuljeFredagKveld))
+
+	if doc.Find("admin-billettholder-search").Length() == 0 {
+		t.Errorf("expected the search web component in the picker")
+	}
+	if doc.Find("button:contains('Legg til som førsteval')").Length() == 0 {
+		t.Errorf("expected the 'add as first choice' button")
+	}
+}

--- a/components/formsubmission/who_is_interested.templ
+++ b/components/formsubmission/who_is_interested.templ
@@ -594,6 +594,19 @@ templ playersInPulje(eventId string, puljeId models.Pulje, interests []InterestW
 	@interestInPulje(eventId, puljeId, interests, true)
 }
 
+// PuljeAssignmentSearch renders the searchable billettholder picker and the
+// "add as player / add as GM" buttons for one pulje, for reuse outside the
+// event-edit page (e.g. the puljefordeling tab). The target event is taken from
+// the $assignmentEventId signal set by the caller before opening the dialog.
+templ PuljeAssignmentSearch(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+	{{ billettholdere, err := getBillettholdere(db, logger) }}
+	if err != nil {
+		<p style="color: var(--color-error);">Kunne ikke hente billettholdere</p>
+	} else {
+		@billettholderAssignmentActions("", pulje, billettholdere)
+	}
+}
+
 templ billettholderAssignmentActions(eventId string, puljeId models.Pulje, billettholdere []Billettholder) {
 	{{ billettholdereJson, _ := json.Marshal(billettholdere) }}
 	<style>

--- a/components/formsubmission/who_is_interested.templ
+++ b/components/formsubmission/who_is_interested.templ
@@ -594,10 +594,6 @@ templ playersInPulje(eventId string, puljeId models.Pulje, interests []InterestW
 	@interestInPulje(eventId, puljeId, interests, true)
 }
 
-// PuljeAssignmentSearch renders the searchable billettholder picker and the
-// "add as player / add as GM" buttons for one pulje, for reuse outside the
-// event-edit page (e.g. the puljefordeling tab). The target event is taken from
-// the $assignmentEventId signal set by the caller before opening the dialog.
 templ PuljeAssignmentSearch(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
 	{{ billettholdere, err := getBillettholdere(db, logger) }}
 	if err != nil {


### PR DESCRIPTION
Splits a small reusability refactor out of #452.

## What's included
- New exported `PuljeAssignmentSearch` templ in `who_is_interested.templ` — wraps the existing `billettholderAssignmentActions` + `getBillettholdere` into a standalone searchable billettholder picker that can be reused outside the event-edit page (it reads the target event from the `$assignmentEventId` signal).
- `assignment_search_test.go` covering the picker + action buttons render.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://456-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->