### PR TITLE
build: add Makefile wrapping the Taskfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+# Makefile — convenience wrapper around the project's Taskfile (go-task).
+#
+# The authoritative task runner is Taskfile.yml (`go tool task ...`). The dev
+# hot-reload, templ-watch and asset-download flows live there; this Makefile
+# delegates to them so there is a single source of truth, and adds a few plain
+# `go` shortcuts (lint/fmt/vet/tidy/check) that the Taskfile does not define.
+#
+# `task` is declared as a go tool, so `go tool task` works without a global
+# install. Run `make` or `make help` for the list of targets.
+
+TASK := go tool task
+
+.DEFAULT_GOAL := help
+
+.PHONY: help build generate start dev run debug test download kill \
+        lint fmt vet tidy check clean
+
+help: ## Show this help
+	@echo "Targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+# --- delegated to Taskfile.yml (go-task) -----------------------------------
+
+build: ## Production build to bin/main (generates templ first)
+	$(TASK) build
+
+generate: ## Generate templ *_templ.go files
+	$(TASK) build:templ
+
+start: ## Dev server with hot reload (templ watch + air)
+	$(TASK) start
+
+dev: start ## Alias for `start`
+
+run: ## Build then run bin/main
+	$(TASK) run
+
+debug: ## Build then launch the delve debugger
+	$(TASK) debug
+
+test: ## Refresh schema.sql and run all tests
+	$(TASK) test
+
+download: ## Download local copies of prod DB + event images
+	$(TASK) download
+
+kill: ## Kill stray main/templ/air/task processes
+	$(TASK) kill
+
+# --- plain go helpers (not in Taskfile) ------------------------------------
+
+lint: ## Run golangci-lint (external binary)
+	@command -v golangci-lint >/dev/null 2>&1 \
+		|| { echo "golangci-lint not found; see https://golangci-lint.run/welcome/install/"; exit 1; }
+	golangci-lint run
+
+fmt: ## Format all Go code
+	go fmt ./...
+
+vet: ## Run go vet
+	go vet ./...
+
+tidy: ## Tidy go.mod / go.sum
+	go mod tidy
+
+check: generate vet test lint ## Generate, vet, test and lint (pre-commit gate)
+
+clean: ## Remove build artifacts
+	rm -rf bin tmp/bin

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,3 @@
-# Makefile — convenience wrapper around the project's Taskfile (go-task).
-#
-# The authoritative task runner is Taskfile.yml (`go tool task ...`). The dev
-# hot-reload, templ-watch and asset-download flows live there; this Makefile
-# delegates to them so there is a single source of truth, and adds a few plain
-# `go` shortcuts (lint/fmt/vet/tidy/check) that the Taskfile does not define.
-#
-# `task` is declared as a go tool, so `go tool task` works without a global
-# install. Run `make` or `make help` for the list of targets.
-
 TASK := go tool task
 
 .DEFAULT_GOAL := help
@@ -20,8 +10,6 @@ help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
 		| sort \
 		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
-
-# --- delegated to Taskfile.yml (go-task) -----------------------------------
 
 build: ## Production build to bin/main (generates templ first)
 	$(TASK) build
@@ -48,8 +36,6 @@ download: ## Download local copies of prod DB + event images
 
 kill: ## Kill stray main/templ/air/task processes
 	$(TASK) kill
-
-# --- plain go helpers (not in Taskfile) ------------------------------------
 
 lint: ## Run golangci-lint (external binary)
 	@command -v golangci-lint >/dev/null 2>&1 \


### PR DESCRIPTION
## Summary

Adds a thin `Makefile` as a convenience wrapper around the project's existing go-task `Taskfile.yml`.

     Targets:
       build        Production build to bin/main (generates templ first)
       check        Generate, vet, test and lint (pre-commit gate)
       clean        Remove build artifacts
       debug        Build then launch the delve debugger
       dev          Alias for `start`
       download     Download local copies of prod DB + event images
       fmt          Format all Go code
       generate     Generate templ *_templ.go files
       help         Show this help
       kill         Kill stray main/templ/air/task processes
       lint         Run golangci-lint (external binary)
       run          Build then run bin/main
       start        Dev server with hot reload (templ watch + air)
       test         Refresh schema.sql and run all tests
       tidy         Tidy go.mod / go.sum
       vet          Run go vet

Split out of #461 (puljefordeling tabbed view) so the feature PR stays focused.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://462-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->