### PR TITLE
Puljefordeling: interactive per-game player assignment

### DIFF
--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/components/formsubmission"
 	"github.com/Regncon/conorganizer/layouts"
 	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/live"
@@ -50,8 +52,9 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 		})
 	})
 
-	// SSE endpoint: streams just the tab content for the viewed pulje, refreshing
-	// whenever events/interests change (BucketEvents), mirroring the rooms api.
+	// SSE endpoint: streams just the tab content for the viewed pulje. The
+	// distribution is driven by interests and manual pins, so it refreshes on both
+	// BucketEvents and BucketInterests (the add endpoints broadcast Interests).
 	router.Get("/api/puljefordeling/{pulje}", func(w http.ResponseWriter, r *http.Request) {
 		puljeQuery := chi.URLParam(r, "pulje")
 		puljeID, ok := models.ParsePulje(puljeQuery)
@@ -61,11 +64,44 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 		}
 
 		liveManager.Stream(w, r, live.Page{
-			Buckets: []live.Bucket{live.BucketEvents},
+			Buckets: []live.Bucket{live.BucketEvents, live.BucketInterests},
 			Render: func(ctx context.Context, r *http.Request) templ.Component {
 				return PuljefordelingTabContent(db, logger, puljeID)
 			},
 		})
+	})
+
+	// Remove a manual pin (×). Manual-only: solver/GM rows are untouched. The
+	// player's interest is kept, so the solver may re-seat them by simulation.
+	router.Delete("/api/puljefordeling/{pulje}/{event}/{billettholderId}", func(w http.ResponseWriter, r *http.Request) {
+		puljeID, ok := models.ParsePulje(chi.URLParam(r, "pulje"))
+		if !ok {
+			http.Error(w, "Invalid pulje ID", http.StatusBadRequest)
+			return
+		}
+		eventID := chi.URLParam(r, "event")
+		if eventID == "" {
+			http.Error(w, "Event ID is required", http.StatusBadRequest)
+			return
+		}
+		billettholderID, err := strconv.Atoi(chi.URLParam(r, "billettholderId"))
+		if err != nil {
+			http.Error(w, "Invalid billettholder ID", http.StatusBadRequest)
+			return
+		}
+
+		if err := puljefordeling.RemoveManualSeat(db, puljeID, eventID, billettholderID); err != nil {
+			logger.Error(err.Error(), "pulje_id", puljeID, "event_id", eventID, "billettholder_id", billettholderID)
+			http.Error(w, "Failed to remove manual seat", http.StatusInternalServerError)
+			return
+		}
+
+		// Best-effort live refresh; a failed broadcast must not fail the request.
+		if err := liveManager.Broadcast(r.Context(), live.BucketEvents); err != nil {
+			logger.Error(fmt.Errorf("failed to broadcast manual seat removal: %w", err).Error(), "pulje_id", puljeID, "event_id", eventID)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
 	})
 }
 
@@ -287,6 +323,36 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
         .pulje-players li.moved {
             border-left: 3px solid #e05050;
         }
+        .pulje-players li.manual {
+            border-left: 3px solid var(--color-primary);
+        }
+        .pulje-remove {
+            margin-left: auto;
+            flex: 0 0 auto;
+            border: none;
+            background: transparent;
+            color: var(--color-text-soft);
+            cursor: pointer;
+            line-height: 1;
+            padding: 0 var(--spacing-1x);
+        }
+        .pulje-remove:hover {
+            color: var(--color-text-error, #e05050);
+        }
+        .pulje-add {
+            align-self: flex-start;
+            margin-top: var(--spacing-1x);
+            border: 1px solid var(--bg-item-border);
+            border-radius: var(--border-radius-1x);
+            background: transparent;
+            color: var(--color-text-soft);
+            cursor: pointer;
+            padding: var(--spacing-1x) var(--spacing-2x);
+        }
+        .pulje-add:hover {
+            border-color: var(--color-primary);
+            color: var(--color-primary);
+        }
         .pulje-emoji {
             flex: 0 0 auto;
             width: 1.4em;
@@ -321,6 +387,10 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		class="rooms-section"
 		data-init={ live.DatastarInit(fmt.Sprintf("/admin/api/puljefordeling/%s", pulje)) }
 		data-signals:pulje-status={ fmt.Sprintf("'%s'", string(row.Status)) }
+		data-signals:assignment-event-id="''"
+		data-signals:assignment-pulje-id="''"
+		data-signals:assignment-billettholder-id="0"
+		data-signals:clear-input="0"
 	>
 		<div class="pulje-tab-header">
 			<div>
@@ -356,7 +426,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		} else {
 			<div class="pulje-event-grid">
 				for _, ev := range result.Events {
-					@puljeEventBox(ev)
+					@puljeEventBox(pulje, ev)
 				}
 			</div>
 			if len(result.Unassigned) > 0 {
@@ -365,8 +435,24 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 					<p>{ strings.Join(result.Unassigned, ", ") }</p>
 				</div>
 			}
+			@puljeAssignDialog(db, logger, pulje)
 		}
 	</section>
+}
+
+// puljeAssignDialog is the single shared picker dialog for the page. The + button
+// on each event box sets $assignmentEventId before opening it, so the picker adds
+// the chosen billettholder to that event (reusing the approval add endpoints).
+templ puljeAssignDialog(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+	<dialog id="puljefordeling-assign-dialog" closedBy="any">
+		<h3>Legg til deltaker</h3>
+		@formsubmission.PuljeAssignmentSearch(db, logger, pulje)
+		<button
+			class="btn btn--outline"
+			type="button"
+			data-on:click="document.getElementById('puljefordeling-assign-dialog').close()"
+		>Lukk</button>
+	</dialog>
 }
 
 templ puljeStatusToggles(pulje models.PuljeRow) {
@@ -406,7 +492,7 @@ templ puljeStatusToggles(pulje models.PuljeRow) {
 	</div>
 }
 
-templ puljeEventBox(ev puljefordeling.EmulatedEvent) {
+templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
 	<div class="pulje-event">
 		<div class="pulje-event-top">
 			<h3>{ ev.Title }</h3>
@@ -421,14 +507,27 @@ templ puljeEventBox(ev puljefordeling.EmulatedEvent) {
 		if len(ev.AssignedPlayers) > 0 {
 			<ul class="pulje-players">
 				for _, pl := range ev.AssignedPlayers {
-					<li class={ templ.KV("moved", pl.Moved) }>
+					<li class={ templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
 						<span class="pulje-emoji">{ pl.Level.Emoji() }</span>
 						<span class={ templ.KV("pulje-dm", pl.IsDM) }>{ pl.Name }</span>
+						if pl.Manual {
+							<button
+								type="button"
+								class="pulje-remove"
+								title="Fjern manuell plassering"
+								data-on:click={ fmt.Sprintf("@delete('/admin/api/puljefordeling/%s/%s/%d')", string(pulje), ev.EventID, pl.BillettholderID) }
+							>×</button>
+						}
 					</li>
 				}
 			</ul>
 		} else {
 			<p class="pulje-empty">Ingen deltakere</p>
 		}
+		<button
+			type="button"
+			class="pulje-add"
+			data-on:click={ fmt.Sprintf("$assignmentEventId = '%s'; $assignmentPuljeId = '%s'; document.getElementById('puljefordeling-assign-dialog').showModal()", ev.EventID, string(pulje)) }
+		>+ Legg til deltaker</button>
 	</div>
 }

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -1,0 +1,102 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/testutil"
+	"github.com/Regncon/conorganizer/testutil/templtest"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestPuljefordelingRemoveManualSeatRoute_DeletesPin(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route")
+	router := chi.NewRouter()
+	puljefordelingRoute(router, db, &live.Manager{}, logger)
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/FredagKveld/evA/1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204 No Content, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players WHERE event_id='evA' AND billettholder_id=1 AND source='manual'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count manual seats: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("manual seat should be deleted, still found %d", n)
+	}
+}
+
+func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_tab_interactive")
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	// Kari is a manual pin → her tile must offer a × that removes her seat.
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
+
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, fredag))
+	html, err := doc.Html()
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+
+	wants := []string{
+		// The shared picker dialog and custom search element are present.
+		"puljefordeling-assign-dialog",
+		"admin-billettholder-search",
+		// The × on Kari's manual tile deletes her manual seat.
+		"/admin/api/puljefordeling/FredagKveld/evA/1",
+	}
+	for _, want := range wants {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered tab should contain %q", want)
+		}
+	}
+
+	// The + button opens the dialog scoped to this event (attribute decoded).
+	addClick := doc.Find(".pulje-add").AttrOr("data-on:click", "")
+	if !strings.Contains(addClick, "$assignmentEventId = 'evA'") {
+		t.Errorf("+ button should set assignmentEventId to the event; got %q", addClick)
+	}
+}
+
+func TestPuljefordelingRemoveManualSeatRoute_RejectsInvalidPulje(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route_invalid")
+	router := chi.NewRouter()
+	puljefordelingRoute(router, db, &live.Manager{}, logger)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/NotAPulje/evA/1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid pulje should be rejected with 400, got %d", rec.Code)
+	}
+}

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -3,11 +3,14 @@ package admin
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/Regncon/conorganizer/components/formsubmission"
 	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/service/puljefordeling"
 	"github.com/Regncon/conorganizer/testutil"
 	"github.com/Regncon/conorganizer/testutil/templtest"
 	"github.com/go-chi/chi/v5"
@@ -84,6 +87,51 @@ func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) 
 	addClick := doc.Find(".pulje-add").AttrOr("data-on:click", "")
 	if !strings.Contains(addClick, "$assignmentEventId = 'evA'") {
 		t.Errorf("+ button should set assignmentEventId to the event; got %q", addClick)
+	}
+}
+
+func TestAddFirstChoiceThenEmulate_PinsAddedPlayer(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_add_then_pin")
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+
+	// Add Kari through the real picker add path (the + button's endpoint).
+	if err := formsubmission.AddPlayersFirstChoice(1, "evA", string(fredag), db, logger); err != nil {
+		t.Fatalf("AddPlayersFirstChoice: %v", err)
+	}
+
+	// A subsequent emulation must pin her into evA, marked as a manual placement.
+	em, err := puljefordeling.EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+	var evA puljefordeling.EmulatedEvent
+	for _, p := range em.Puljer {
+		if p.PuljeID == fredag {
+			for _, e := range p.Events {
+				if e.EventID == "evA" {
+					evA = e
+				}
+			}
+		}
+	}
+	names := make([]string, len(evA.AssignedPlayers))
+	for i, ap := range evA.AssignedPlayers {
+		names[i] = ap.Name
+	}
+	if !slices.Contains(names, "Kari Nordmann") {
+		t.Fatalf("added player should be pinned into evA, got %v", names)
+	}
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Kari Nordmann" && !ap.Manual {
+			t.Errorf("added player should be marked as a manual placement")
+		}
 	}
 }
 

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -18,11 +18,12 @@ import (
 // show how much they wanted this game, whether they carry the DM bump, and
 // whether they were bumped off a stronger preference to make room for others.
 type AssignedPlayer struct {
-	Name   string
-	IsDM   bool                 // runs at least one game in the weekend (DM bump)
-	Level  models.InterestLevel // their interest in the game they got
-	Moved  bool                 // relocated off a higher-scoring event by the solver to make room for others
-	Manual bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
+	BillettholderID int // participant id, for manual-seat removal from the UI
+	Name            string
+	IsDM            bool                 // runs at least one game in the weekend (DM bump)
+	Level           models.InterestLevel // their interest in the game they got
+	Moved           bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Manual          bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
 }
 
 // Seat sources recorded on relation_events_players. Manual seats are admin pins
@@ -211,7 +212,7 @@ func assignedPlayers(
 			out = append(out, AssignedPlayer{Name: id})
 			continue
 		}
-		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
+		ap := AssignedPlayer{BillettholderID: bh, Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
 		if byPulje, ok := prefs[bh]; ok {
 			got := byPulje[puljeID][eventID]
 			ap.Level = models.InterestLevelFromScore(int(got))

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -18,11 +18,19 @@ import (
 // show how much they wanted this game, whether they carry the DM bump, and
 // whether they were bumped off a stronger preference to make room for others.
 type AssignedPlayer struct {
-	Name  string
-	IsDM  bool                 // runs at least one game in the weekend (DM bump)
-	Level models.InterestLevel // their interest in the game they got
-	Moved bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Name   string
+	IsDM   bool                 // runs at least one game in the weekend (DM bump)
+	Level  models.InterestLevel // their interest in the game they got
+	Moved  bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Manual bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
 }
+
+// Seat sources recorded on relation_events_players. Manual seats are admin pins
+// the solver must honour; solver seats are produced by a committed distribution.
+const (
+	SourceManual = "manual"
+	SourceSolver = "solver"
+)
 
 // EmulatedEvent is the proposed seating for a single event within a pulje.
 type EmulatedEvent struct {
@@ -85,6 +93,10 @@ func EmulateSeatings(db *sql.DB) (Emulation, error) {
 	if err != nil {
 		return Emulation{}, err
 	}
+	pins, err := loadManualPins(db) // pulje -> playerID -> eventID (admin manual seats)
+	if err != nil {
+		return Emulation{}, err
+	}
 
 	// Build the solver's Weekend in chronological pulje order.
 	weekend := smodel.Weekend{Slots: make([]smodel.Slot, 0, len(puljer))}
@@ -123,8 +135,8 @@ func EmulateSeatings(db *sql.DB) (Emulation, error) {
 	emulation := Emulation{Year: year, PlayerCount: len(players)}
 	for i, slot := range weekend.Slots {
 		pulje := puljer[i]
-		res := state.SolveSlot(slot, players)
-		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet))
+		res := state.SolveSlotFixed(slot, players, pins[pulje.ID])
+		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet, pins[pulje.ID]))
 	}
 	emulation.SatisfiedTotal = state.SatisfiedCount()
 
@@ -140,6 +152,7 @@ func shapePulje(
 	names map[int]string,
 	prefs map[int]map[string]map[string]smodel.Score,
 	dmSet map[int]bool,
+	manual map[string]string,
 ) EmulatedPulje {
 	under := make(map[string]bool, len(res.UndersubscribedEvents))
 	for _, eid := range res.UndersubscribedEvents {
@@ -164,7 +177,7 @@ func shapePulje(
 			EventID:         ev.ID,
 			Title:           ev.Name,
 			Capacity:        ev.Capacity,
-			AssignedPlayers: assignedPlayers(res.Assignments[ev.ID], ev.ID, string(pulje.ID), names, prefs, dmSet, moved),
+			AssignedPlayers: assignedPlayers(res.Assignments[ev.ID], ev.ID, string(pulje.ID), names, prefs, dmSet, moved, manual),
 			Undersubscribed: under[ev.ID],
 		}
 		if gmID, ok := gms[eventPuljeKey(ev.ID, pulje.ID)]; ok {
@@ -186,6 +199,7 @@ func assignedPlayers(
 	prefs map[int]map[string]map[string]smodel.Score,
 	dmSet map[int]bool,
 	moved map[string]bool,
+	manual map[string]string,
 ) []AssignedPlayer {
 	if len(ids) == 0 {
 		return nil
@@ -197,7 +211,7 @@ func assignedPlayers(
 			out = append(out, AssignedPlayer{Name: id})
 			continue
 		}
-		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id]}
+		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
 		if byPulje, ok := prefs[bh]; ok {
 			got := byPulje[puljeID][eventID]
 			ap.Level = models.InterestLevelFromScore(int(got))
@@ -258,6 +272,38 @@ func loadEligibleEvents(db *sql.DB) (map[models.Pulje]map[string]eligibleEvent, 
 			out[pulje] = make(map[string]eligibleEvent)
 		}
 		out[pulje][eventID] = eligibleEvent{title: title, capacity: maxPlayers}
+	}
+	return out, rows.Err()
+}
+
+// loadManualPins returns the admin-pinned player seats keyed by pulje, then by
+// solver player ID (the billettholder ID as a string) → event ID. These are
+// fed to the solver as fixed placements so a manually-added player is reserved
+// into their event regardless of expressed interest.
+func loadManualPins(db *sql.DB) (map[models.Pulje]map[string]string, error) {
+	const query = `
+		SELECT pulje_id, event_id, billettholder_id
+		FROM relation_events_players
+		WHERE source = ? AND role = ?
+	`
+	rows, err := db.Query(query, SourceManual, models.EventPlayerRolePlayer)
+	if err != nil {
+		return nil, fmt.Errorf("query manual pins: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[models.Pulje]map[string]string)
+	for rows.Next() {
+		var pulje models.Pulje
+		var eventID string
+		var bhID int
+		if err := rows.Scan(&pulje, &eventID, &bhID); err != nil {
+			return nil, fmt.Errorf("scan manual pin row: %w", err)
+		}
+		if out[pulje] == nil {
+			out[pulje] = make(map[string]string)
+		}
+		out[pulje][strconv.Itoa(bhID)] = eventID
 	}
 	return out, rows.Err()
 }

--- a/service/puljefordeling/manual_pins.go
+++ b/service/puljefordeling/manual_pins.go
@@ -1,0 +1,25 @@
+package puljefordeling
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Regncon/conorganizer/models"
+)
+
+// RemoveManualSeat deletes an admin-pinned player seat (source='manual',
+// role='Player') for the given pulje/event/participant. It only removes manual
+// player pins — solver seats and GM rows are left untouched. Removing the pin
+// does not touch the player's interest, so a later emulation may still seat them
+// in the same event by simulation (now as a non-manual placement).
+func RemoveManualSeat(db *sql.DB, pulje models.Pulje, eventID string, billettholderID int) error {
+	const query = `
+		DELETE FROM relation_events_players
+		WHERE event_id = ? AND pulje_id = ? AND billettholder_id = ?
+		  AND source = ? AND role = ?
+	`
+	if _, err := db.Exec(query, eventID, string(pulje), billettholderID, SourceManual, models.EventPlayerRolePlayer); err != nil {
+		return fmt.Errorf("remove manual seat (pulje=%s event=%s bh=%d): %w", pulje, eventID, billettholderID, err)
+	}
+	return nil
+}

--- a/service/puljefordeling/manual_pins_test.go
+++ b/service/puljefordeling/manual_pins_test.go
@@ -1,0 +1,210 @@
+package puljefordeling
+
+import (
+	"database/sql"
+	"slices"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func TestEmulateSeatings_ManualPinSeatsPlayerWithoutInterest(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+
+	// Kari expressed NO interest in evA. A manual seat (source='manual') must
+	// still pin her into evA when the distribution is emulated.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	evA, ok := findEvent(em.Puljer[0], "evA")
+	if !ok {
+		t.Fatal("evA missing from result")
+	}
+	if !slices.Contains(playerNames(evA.AssignedPlayers), "Kari Nordmann") {
+		t.Fatalf("manual pin should seat Kari in evA, got %v", playerNames(evA.AssignedPlayers))
+	}
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Kari Nordmann" && !ap.Manual {
+			t.Errorf("Kari was added manually and should be marked Manual")
+		}
+	}
+}
+
+func manualSeatCount(t *testing.T, db interface {
+	QueryRow(string, ...any) *sql.Row
+}, eventID string, pulje models.Pulje, bhID int) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players
+		 WHERE event_id = ? AND pulje_id = ? AND billettholder_id = ? AND source = 'manual' AND role = 'Player'`,
+		eventID, string(pulje), bhID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count manual seats: %v", err)
+	}
+	return n
+}
+
+func TestRemoveManualSeat_DeletesManualPlayerSeat(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "remove_manual_seat")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	if err := RemoveManualSeat(db, fredag, "evA", 1); err != nil {
+		t.Fatalf("RemoveManualSeat: %v", err)
+	}
+
+	if got := manualSeatCount(t, db, "evA", fredag, 1); got != 0 {
+		t.Fatalf("manual seat should be deleted, still found %d", got)
+	}
+}
+
+func TestRemoveManualSeat_LeavesSolverSeatIntact(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "remove_manual_seat_guard")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+	// A solver-sourced seat must not be removable through the manual-remove path.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'solver')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed solver seat: %v", err)
+	}
+
+	if err := RemoveManualSeat(db, fredag, "evA", 1); err != nil {
+		t.Fatalf("RemoveManualSeat: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players WHERE source = 'solver'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count solver seats: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("solver seat must remain, found %d", n)
+	}
+}
+
+func TestEmulateSeatings_PinnedPlayerCountsAsSatisfiedAndScored(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin_satisfied")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	// One seat in evA; two participants want it as their top choice.
+	seedEvent(t, db, "evA", "Alpha", 1, fredag)
+	seedParticipant(t, db, 1, "Pin", "Ned")
+	seedParticipant(t, db, 2, "Loser", "Out")
+	seedInterest(t, db, 1, "evA", fredag, models.InterestLevelHigh)
+	seedInterest(t, db, 2, "evA", fredag, models.InterestLevelHigh)
+
+	// Pin the player who DID want evA (top choice) into the single seat.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	p := em.Puljer[0]
+	// The pinned player wanted evA as a top choice, so pinning them there must
+	// count as a newly-satisfied top choice and contribute their score.
+	if p.NewlySatisfied != 1 {
+		t.Errorf("pinned top-choice player should be newly satisfied: want 1, got %d", p.NewlySatisfied)
+	}
+	if em.SatisfiedTotal != 1 {
+		t.Errorf("satisfied total: want 1, got %d", em.SatisfiedTotal)
+	}
+	if p.TotalScore < int(models.InterestLevelHigh.Score()) {
+		t.Errorf("pinned top-choice player should contribute their score; total score too low: %d", p.TotalScore)
+	}
+
+	evA, _ := findEvent(p, "evA")
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Pin Ned" {
+			if !ap.Manual {
+				t.Errorf("pinned player should be marked Manual")
+			}
+			if ap.Level != models.InterestLevelHigh {
+				t.Errorf("pinned player's surfaced interest level: want High, got %q", ap.Level)
+			}
+		}
+	}
+}
+
+func TestEmulateSeatings_ManualPinReservesSeatUnderContention(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin_contention")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	// Single seat in evA; two highly-interested regulars compete for it.
+	seedEvent(t, db, "evA", "Alpha", 1, fredag)
+	seedParticipant(t, db, 1, "Pin", "Ned")
+	seedParticipant(t, db, 2, "Eager", "One")
+	seedParticipant(t, db, 3, "Eager", "Two")
+	seedInterest(t, db, 2, "evA", fredag, models.InterestLevelHigh)
+	seedInterest(t, db, 3, "evA", fredag, models.InterestLevelHigh)
+
+	// Admin pins Pin Ned into the single evA seat; the solver must honour it and
+	// leave the eager regulars without that seat.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	evA, ok := findEvent(em.Puljer[0], "evA")
+	if !ok {
+		t.Fatal("evA missing from result")
+	}
+	names := playerNames(evA.AssignedPlayers)
+	if !slices.Contains(names, "Pin Ned") {
+		t.Fatalf("pinned player must keep the contested seat, got %v", names)
+	}
+	if len(evA.AssignedPlayers) != 1 {
+		t.Fatalf("evA capacity is 1 and a pin fills it; want 1 seated, got %v", names)
+	}
+}

--- a/service/puljefordeling/manual_pins_test.go
+++ b/service/puljefordeling/manual_pins_test.go
@@ -40,8 +40,13 @@ func TestEmulateSeatings_ManualPinSeatsPlayerWithoutInterest(t *testing.T) {
 		t.Fatalf("manual pin should seat Kari in evA, got %v", playerNames(evA.AssignedPlayers))
 	}
 	for _, ap := range evA.AssignedPlayers {
-		if ap.Name == "Kari Nordmann" && !ap.Manual {
-			t.Errorf("Kari was added manually and should be marked Manual")
+		if ap.Name == "Kari Nordmann" {
+			if !ap.Manual {
+				t.Errorf("Kari was added manually and should be marked Manual")
+			}
+			if ap.BillettholderID != 1 {
+				t.Errorf("assigned player should carry the billettholder id for removal: want 1, got %d", ap.BillettholderID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

**interactive per-game assignment**: add a player/GM to a game via the shared picker, and remove a manual pin. The distribution now honours admin pins, while staying a what-if view (no lock-commit persistence of solver seats — that stays deferred).

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://463-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->