### PR TITLE
Puljefordeling: interactive per-game player assignment

### DIFF
--- a/components/formsubmission/assignment_search_test.go
+++ b/components/formsubmission/assignment_search_test.go
@@ -1,6 +1,7 @@
 package formsubmission
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Regncon/conorganizer/models"
@@ -25,5 +26,15 @@ func TestPuljeAssignmentSearch_RendersPickerAndButtons(t *testing.T) {
 	}
 	if doc.Find("button:contains('Legg til som førsteval')").Length() == 0 {
 		t.Errorf("expected the 'add as first choice' button")
+	}
+
+	// The puljefordeling picker only adds players. The DM is the game's owner,
+	// not a participant you pick here, so it must not offer an "add as GM" action.
+	html, err := doc.Html()
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+	if strings.Contains(html, "add_gm") {
+		t.Errorf("puljefordeling picker must not offer an 'add as GM' action")
 	}
 }

--- a/components/formsubmission/who_is_interested.templ
+++ b/components/formsubmission/who_is_interested.templ
@@ -664,11 +664,34 @@ templ billettholderAssignmentActions(eventId string, puljeId models.Pulje, bille
 
 templ puljeSection(eventId string, pulje models.PuljeRow, interests []InterestWithHolder, assignees []InterestWithHolder, showGmForm bool, billettholdere []Billettholder) {
 	{{ puljeId := pulje.ID }}
+	{{
+		hasGM := false
+		for _, a := range assignees {
+			if a.PuljeId == string(puljeId) && a.IsGamemaster {
+				hasGM = true
+				break
+			}
+		}
+	}}
 	<article
 		class="form-card"
 		data-style:display={ fmt.Sprintf("(!$isInPulje%s || !$isPublished%s) && 'none' || ''", puljeId, puljeId) }
 	>
+		<style>
+			.missing-dm-badge {
+				align-self: flex-start;
+				display: inline-block;
+				padding: 0 var(--spacing-2x);
+				border-radius: var(--border-radius-1x);
+				background-color: var(--bg-surface);
+				color: var(--color-text-error, #e05050);
+				font-size: var(--text-small, 0.85rem);
+			}
+		</style>
 		<h2 style="margin-bottom:1rem;">{ pulje.Name } <span>({ pulje.TimeRange() })</span></h2>
+		if !hasGM {
+			<span class="missing-dm-badge">Mangler spilleder</span>
+		}
 		<h2 style="margin-bottom:1rem;">Finn billettholder!</h2>
 		@billettholderAssignmentActions(eventId, puljeId, billettholdere, true)
 		<h2 style="margin-bottom:1rem;">Kven er tildelt?</h2>

--- a/components/formsubmission/who_is_interested.templ
+++ b/components/formsubmission/who_is_interested.templ
@@ -599,11 +599,11 @@ templ PuljeAssignmentSearch(db *sql.DB, logger *slog.Logger, pulje models.Pulje)
 	if err != nil {
 		<p style="color: var(--color-error);">Kunne ikke hente billettholdere</p>
 	} else {
-		@billettholderAssignmentActions("", pulje, billettholdere)
+		@billettholderAssignmentActions("", pulje, billettholdere, false)
 	}
 }
 
-templ billettholderAssignmentActions(eventId string, puljeId models.Pulje, billettholdere []Billettholder) {
+templ billettholderAssignmentActions(eventId string, puljeId models.Pulje, billettholdere []Billettholder, showGM bool) {
 	{{ billettholdereJson, _ := json.Marshal(billettholdere) }}
 	<style>
 		.billettholder-search {
@@ -643,12 +643,14 @@ templ billettholderAssignmentActions(eventId string, puljeId models.Pulje, bille
 			input-tippy="Søk etter billettholder"
 		></admin-billettholder-search>
 		<div class="billettholder-search-buttons">
-			<button
-				class="btn btn--secondary"
-				data-on:click={ fmt.Sprintf("$assignmentPuljeId = '%s'; @post('/admin/approval/api/event-players/post/add_gm'); evt.currentTarget.closest('.billettholder-search')?.querySelector('admin-billettholder-search')?.clearSearch(); $assignmentBillettholderId = 0; $clearInput = $clearInput + 1", puljeId) }
-			>
-				Legg til som { models.EventPlayerRoleGM.Label() }
-			</button>
+			if showGM {
+				<button
+					class="btn btn--secondary"
+					data-on:click={ fmt.Sprintf("$assignmentPuljeId = '%s'; @post('/admin/approval/api/event-players/post/add_gm'); evt.currentTarget.closest('.billettholder-search')?.querySelector('admin-billettholder-search')?.clearSearch(); $assignmentBillettholderId = 0; $clearInput = $clearInput + 1", puljeId) }
+				>
+					Legg til som { models.EventPlayerRoleGM.Label() }
+				</button>
+			}
 			<button
 				class="btn btn--secondary"
 				data-on:click={ fmt.Sprintf("$assignmentPuljeId = '%s'; @post('/admin/approval/api/event-players/post/add_first_choice'); evt.currentTarget.closest('.billettholder-search')?.querySelector('admin-billettholder-search')?.clearSearch(); $assignmentBillettholderId = 0; $clearInput = $clearInput + 1", puljeId) }
@@ -668,7 +670,7 @@ templ puljeSection(eventId string, pulje models.PuljeRow, interests []InterestWi
 	>
 		<h2 style="margin-bottom:1rem;">{ pulje.Name } <span>({ pulje.TimeRange() })</span></h2>
 		<h2 style="margin-bottom:1rem;">Finn billettholder!</h2>
-		@billettholderAssignmentActions(eventId, puljeId, billettholdere)
+		@billettholderAssignmentActions(eventId, puljeId, billettholdere, true)
 		<h2 style="margin-bottom:1rem;">Kven er tildelt?</h2>
 		@playersInPulje(eventId, puljeId, assignees)
 		<h2 style="margin-bottom:1rem;">Kven er interessert?</h2>

--- a/components/formsubmission/who_is_interested_test.go
+++ b/components/formsubmission/who_is_interested_test.go
@@ -1,10 +1,13 @@
 package formsubmission
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/testutil"
 	"github.com/Regncon/conorganizer/testutil/bdd"
+	"github.com/Regncon/conorganizer/testutil/templtest"
 )
 
 const (
@@ -149,4 +152,48 @@ func TestGetInterestsForEvent_FirstChoiceRules(t *testing.T) {
 			expectFirstChoice(t, actualE4Interests, tc)
 		}
 	})
+}
+
+func TestPuljeSection_FlagsMissingDm(t *testing.T) {
+	bdd.Behavior(t, bdd.BDD{
+		Given: "Gitt en pulje der arrangementet ikke har en tildelt spilleder.",
+		When:  "Når puljeseksjonen på godkjenningssiden rendres.",
+		Then:  "Så skal den vise 'Mangler spilleder'.",
+	})
+
+	pulje := models.PuljeRow{ID: models.PuljeFredagKveld, Name: "Fredag Kveld"}
+	assignees := []InterestWithHolder{
+		{BillettholderId: 1, EventId: "evA", PuljeId: string(models.PuljeFredagKveld), IsGamemaster: false, FirstName: "Kari", LastName: "Nordmann"},
+	}
+
+	doc := templtest.Render(t, puljeSection("evA", pulje, nil, assignees, true, nil))
+	html, err := doc.Html()
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+	if !strings.Contains(html, "Mangler spilleder") {
+		t.Fatalf("pulje without a DM should show 'Mangler spilleder'")
+	}
+}
+
+func TestPuljeSection_NoMissingDmFlagWhenGmAssigned(t *testing.T) {
+	bdd.Behavior(t, bdd.BDD{
+		Given: "Gitt en pulje der arrangementet har en tildelt spilleder.",
+		When:  "Når puljeseksjonen på godkjenningssiden rendres.",
+		Then:  "Så skal den ikke vise 'Mangler spilleder'.",
+	})
+
+	pulje := models.PuljeRow{ID: models.PuljeFredagKveld, Name: "Fredag Kveld"}
+	assignees := []InterestWithHolder{
+		{BillettholderId: 9, EventId: "evA", PuljeId: string(models.PuljeFredagKveld), IsGamemaster: true, FirstName: "Game", LastName: "Master"},
+	}
+
+	doc := templtest.Render(t, puljeSection("evA", pulje, nil, assignees, true, nil))
+	html, err := doc.Html()
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+	if strings.Contains(html, "Mangler spilleder") {
+		t.Fatalf("pulje with a GM should not show 'Mangler spilleder'")
+	}
 }

--- a/pages/admin/puljefordeling.go
+++ b/pages/admin/puljefordeling.go
@@ -50,6 +50,14 @@ func getPuljer(db *sql.DB) ([]models.PuljeRow, error) {
 	return puljer, nil
 }
 
+func getPuljeStatus(db *sql.DB, pulje models.Pulje) (models.PuljeStatus, error) {
+	var status models.PuljeStatus
+	if err := db.QueryRow(`SELECT status FROM puljer WHERE id = ?`, pulje).Scan(&status); err != nil {
+		return "", fmt.Errorf("get pulje %s status: %w", pulje, err)
+	}
+	return status, nil
+}
+
 func isValidPuljeStatus(status models.PuljeStatus) bool {
 	switch status {
 	case models.PuljeStatusOpen, models.PuljeStatusLocked, models.PuljeStatusCompleted:

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -90,6 +90,18 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 			return
 		}
 
+		// A published pulje is frozen: no assignment changes until it is unpublished.
+		status, err := getPuljeStatus(db, puljeID)
+		if err != nil {
+			logger.Error(err.Error(), "pulje_id", puljeID)
+			http.Error(w, "Failed to read pulje status", http.StatusInternalServerError)
+			return
+		}
+		if puljeIsCompleted(status) {
+			http.Error(w, "Pulje is published; changes are not allowed", http.StatusConflict)
+			return
+		}
+
 		if err := puljefordeling.RemoveManualSeat(db, puljeID, eventID, billettholderID); err != nil {
 			logger.Error(err.Error(), "pulje_id", puljeID, "event_id", eventID, "billettholder_id", billettholderID)
 			http.Error(w, "Failed to remove manual seat", http.StatusInternalServerError)
@@ -435,7 +447,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		} else {
 			<div class="pulje-event-grid">
 				for _, ev := range result.Events {
-					@puljeEventBox(pulje, ev)
+					@puljeEventBox(pulje, ev, puljeIsCompleted(row.Status))
 				}
 			</div>
 			if len(result.Unassigned) > 0 {
@@ -500,7 +512,7 @@ templ puljeStatusToggles(pulje models.PuljeRow) {
 	</div>
 }
 
-templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
+templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, published bool) {
 	<div class={ "pulje-event", templ.KV("missing-dm", ev.GMName == "") }>
 		<div class="pulje-event-top">
 			<h3>{ ev.Title }</h3>
@@ -520,7 +532,7 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
 					<li class={ templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
 						<span class="pulje-emoji">{ pl.Level.Emoji() }</span>
 						<span class={ templ.KV("pulje-dm", pl.IsDM) }>{ pl.Name }</span>
-						if pl.Manual {
+						if pl.Manual && !published {
 							<button
 								type="button"
 								class="pulje-remove"
@@ -534,10 +546,12 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
 		} else {
 			<p class="pulje-empty">Ingen deltakere</p>
 		}
-		<button
-			type="button"
-			class="pulje-add"
-			data-on:click={ fmt.Sprintf("$assignmentEventId = '%s'; $assignmentPuljeId = '%s'; document.getElementById('puljefordeling-assign-dialog').showModal()", ev.EventID, string(pulje)) }
-		>+ Legg til deltaker</button>
+		if !published {
+			<button
+				type="button"
+				class="pulje-add"
+				data-on:click={ fmt.Sprintf("$assignmentEventId = '%s'; $assignmentPuljeId = '%s'; document.getElementById('puljefordeling-assign-dialog').showModal()", ev.EventID, string(pulje)) }
+			>+ Legg til deltaker</button>
+		}
 	</div>
 }

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -303,11 +303,11 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             font-style: italic;
         }
         .pulje-gm-missing {
-            color: var(--color-text-warning, #e0a030);
+            color: var(--color-text-error, #e05050);
             font-style: italic;
         }
         .pulje-event.missing-dm {
-            border-color: var(--color-text-warning, #e0a030);
+            border-color: var(--color-text-error, #e05050);
         }
         .pulje-badge {
             align-self: flex-start;

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -302,9 +302,8 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             color: var(--color-text-soft);
             font-style: italic;
         }
-        .pulje-gm-missing {
+        .pulje-badge--error {
             color: var(--color-text-error, #e05050);
-            font-style: italic;
         }
         .pulje-event.missing-dm {
             border-color: var(--color-text-error, #e05050);
@@ -510,7 +509,7 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
 		if ev.GMName != "" {
 			<p class="pulje-gm">Spilleder: { ev.GMName }</p>
 		} else {
-			<p class="pulje-gm-missing">Mangler spilleder</p>
+			<span class="pulje-badge pulje-badge--error">Mangler spilleder</span>
 		}
 		if ev.Undersubscribed {
 			<span class="pulje-badge">Få deltakere</span>

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -268,15 +268,26 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             cursor: pointer;
         }
         .pulje-legend {
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-1x);
             color: var(--color-text-soft);
             font-size: var(--text-small, 0.85rem);
         }
-        .pulje-legend .pulje-dm {
-            color: turquoise;
+        .pulje-legend p {
+            margin: 0;
         }
-        .pulje-legend .pulje-moved {
-            border-left: 3px solid #e05050;
+        .pulje-legend .legend-strek {
             padding-left: var(--spacing-1x);
+        }
+        .pulje-legend .legend-dm {
+            border-left: 3px solid var(--color-accent-blue);
+        }
+        .pulje-legend .legend-moved {
+            border-left: 3px solid var(--color-accent-red);
+        }
+        .pulje-legend .legend-manual {
+            border-left: 3px solid var(--color-accent-yellow);
         }
         .pulje-event-grid {
             display: grid;
@@ -345,11 +356,14 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             border: 1px solid var(--bg-item-border);
             border-radius: var(--border-radius-1x);
         }
+        .pulje-players li.dm {
+            border-left: 3px solid var(--color-accent-blue);
+        }
         .pulje-players li.moved {
-            border-left: 3px solid #e05050;
+            border-left: 3px solid var(--color-accent-red);
         }
         .pulje-players li.manual {
-            border-left: 3px solid var(--color-primary);
+            border-left: 3px solid var(--color-accent-yellow);
         }
         .pulje-remove {
             margin-left: auto;
@@ -382,9 +396,6 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             flex: 0 0 auto;
             width: 1.4em;
             text-align: center;
-        }
-        .pulje-dm {
-            color: turquoise;
         }
         .pulje-empty {
             color: var(--color-text-soft-50);
@@ -437,9 +448,12 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 				@puljeStatusToggles(row)
 			}
 		</div>
-		<p class="pulje-legend">
-			🔥 Veldig interessert · 👍 Middels · 🤷 Litt · <span class="pulje-dm">Turkis</span> = spilleder et annet sted · <span class="pulje-moved">Rød strek</span> = flyttet ned for å gi plass til andre
-		</p>
+		<div class="pulje-legend">
+			<p>🔥 Veldig interessert · 👍 Middels · 🤷 Litt</p>
+			<p>
+				<span class="legend-strek legend-dm">Blå strek</span> = Spilleder · <span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
+			</p>
+		</div>
 		if emErr != nil {
 			<p class="pulje-error">Kunne ikke beregne fordeling: { emErr.Error() }</p>
 		} else if !hasResult {
@@ -529,9 +543,9 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, publish
 		if len(ev.AssignedPlayers) > 0 {
 			<ul class="pulje-players">
 				for _, pl := range ev.AssignedPlayers {
-					<li class={ templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
+					<li class={ templ.KV("dm", pl.IsDM), templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
 						<span class="pulje-emoji">{ pl.Level.Emoji() }</span>
-						<span class={ templ.KV("pulje-dm", pl.IsDM) }>{ pl.Name }</span>
+						<span>{ pl.Name }</span>
 						if pl.Manual && !published {
 							<button
 								type="button"

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -280,8 +280,8 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
         .pulje-legend .legend-strek {
             padding-left: var(--spacing-1x);
         }
-        .pulje-legend .legend-dm {
-            border-left: 3px solid var(--color-accent-blue);
+        .pulje-legend .legend-dm-name {
+            color: turquoise;
         }
         .pulje-legend .legend-moved {
             border-left: 3px solid var(--color-accent-red);
@@ -356,14 +356,14 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             border: 1px solid var(--bg-item-border);
             border-radius: var(--border-radius-1x);
         }
-        .pulje-players li.dm {
-            border-left: 3px solid var(--color-accent-blue);
-        }
         .pulje-players li.moved {
             border-left: 3px solid var(--color-accent-red);
         }
         .pulje-players li.manual {
             border-left: 3px solid var(--color-accent-yellow);
+        }
+        .pulje-dm {
+            color: turquoise;
         }
         .pulje-remove {
             margin-left: auto;
@@ -451,7 +451,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		<div class="pulje-legend">
 			<p>🔥 Veldig interessert · 👍 Middels · 🤷 Litt</p>
 			<p>
-				<span class="legend-strek legend-dm">Blå strek</span> = Spilleder · <span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
+				<span class="legend-dm-name">Turkis navn</span> = Spilleder · <span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
 			</p>
 		</div>
 		if emErr != nil {
@@ -543,9 +543,9 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, publish
 		if len(ev.AssignedPlayers) > 0 {
 			<ul class="pulje-players">
 				for _, pl := range ev.AssignedPlayers {
-					<li class={ templ.KV("dm", pl.IsDM), templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
+					<li class={ templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
 						<span class="pulje-emoji">{ pl.Level.Emoji() }</span>
-						<span>{ pl.Name }</span>
+						<span class={ templ.KV("pulje-dm", pl.IsDM) }>{ pl.Name }</span>
 						if pl.Manual && !published {
 							<button
 								type="button"

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/components/formsubmission"
 	"github.com/Regncon/conorganizer/layouts"
 	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/live"
@@ -50,8 +52,9 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 		})
 	})
 
-	// SSE endpoint: streams just the tab content for the viewed pulje, refreshing
-	// whenever events/interests change (BucketEvents), mirroring the rooms api.
+	// SSE endpoint: streams just the tab content for the viewed pulje. The
+	// distribution is driven by interests and manual pins, so it refreshes on both
+	// BucketEvents and BucketInterests (the add endpoints broadcast Interests).
 	router.Get("/api/puljefordeling/{pulje}", func(w http.ResponseWriter, r *http.Request) {
 		puljeQuery := chi.URLParam(r, "pulje")
 		puljeID, ok := models.ParsePulje(puljeQuery)
@@ -61,11 +64,44 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 		}
 
 		liveManager.Stream(w, r, live.Page{
-			Buckets: []live.Bucket{live.BucketEvents},
+			Buckets: []live.Bucket{live.BucketEvents, live.BucketInterests},
 			Render: func(ctx context.Context, r *http.Request) templ.Component {
 				return PuljefordelingTabContent(db, logger, puljeID)
 			},
 		})
+	})
+
+	// Remove a manual pin (×). Manual-only: solver/GM rows are untouched. The
+	// player's interest is kept, so the solver may re-seat them by simulation.
+	router.Delete("/api/puljefordeling/{pulje}/{event}/{billettholderId}", func(w http.ResponseWriter, r *http.Request) {
+		puljeID, ok := models.ParsePulje(chi.URLParam(r, "pulje"))
+		if !ok {
+			http.Error(w, "Invalid pulje ID", http.StatusBadRequest)
+			return
+		}
+		eventID := chi.URLParam(r, "event")
+		if eventID == "" {
+			http.Error(w, "Event ID is required", http.StatusBadRequest)
+			return
+		}
+		billettholderID, err := strconv.Atoi(chi.URLParam(r, "billettholderId"))
+		if err != nil {
+			http.Error(w, "Invalid billettholder ID", http.StatusBadRequest)
+			return
+		}
+
+		if err := puljefordeling.RemoveManualSeat(db, puljeID, eventID, billettholderID); err != nil {
+			logger.Error(err.Error(), "pulje_id", puljeID, "event_id", eventID, "billettholder_id", billettholderID)
+			http.Error(w, "Failed to remove manual seat", http.StatusInternalServerError)
+			return
+		}
+
+		// Best-effort live refresh; a failed broadcast must not fail the request.
+		if err := liveManager.Broadcast(r.Context(), live.BucketEvents); err != nil {
+			logger.Error(fmt.Errorf("failed to broadcast manual seat removal: %w", err).Error(), "pulje_id", puljeID, "event_id", eventID)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
 	})
 }
 
@@ -287,6 +323,36 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
         .pulje-players li.moved {
             border-left: 3px solid #e05050;
         }
+        .pulje-players li.manual {
+            border-left: 3px solid var(--color-primary);
+        }
+        .pulje-remove {
+            margin-left: auto;
+            flex: 0 0 auto;
+            border: none;
+            background: transparent;
+            color: var(--color-text-soft);
+            cursor: pointer;
+            line-height: 1;
+            padding: 0 var(--spacing-1x);
+        }
+        .pulje-remove:hover {
+            color: var(--color-text-error, #e05050);
+        }
+        .pulje-add {
+            align-self: flex-start;
+            margin-top: var(--spacing-1x);
+            border: 1px solid var(--bg-item-border);
+            border-radius: var(--border-radius-1x);
+            background: transparent;
+            color: var(--color-text-soft);
+            cursor: pointer;
+            padding: var(--spacing-1x) var(--spacing-2x);
+        }
+        .pulje-add:hover {
+            border-color: var(--color-primary);
+            color: var(--color-primary);
+        }
         .pulje-emoji {
             flex: 0 0 auto;
             width: 1.4em;
@@ -321,6 +387,10 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		class="rooms-section"
 		data-init={ live.DatastarInit(fmt.Sprintf("/admin/api/puljefordeling/%s", pulje)) }
 		data-signals:pulje-status={ fmt.Sprintf("'%s'", string(row.Status)) }
+		data-signals:assignment-event-id="''"
+		data-signals:assignment-pulje-id="''"
+		data-signals:assignment-billettholder-id="0"
+		data-signals:clear-input="0"
 	>
 		<div class="pulje-tab-header">
 			<div>
@@ -356,7 +426,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		} else {
 			<div class="pulje-event-grid">
 				for _, ev := range result.Events {
-					@puljeEventBox(ev)
+					@puljeEventBox(pulje, ev)
 				}
 			</div>
 			if len(result.Unassigned) > 0 {
@@ -365,8 +435,24 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 					<p>{ strings.Join(result.Unassigned, ", ") }</p>
 				</div>
 			}
+			@puljeAssignDialog(db, logger, pulje)
 		}
 	</section>
+}
+
+// puljeAssignDialog is the single shared picker dialog for the page. The + button
+// on each event box sets $assignmentEventId before opening it, so the picker adds
+// the chosen billettholder to that event (reusing the approval add endpoints).
+templ puljeAssignDialog(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+	<dialog id="puljefordeling-assign-dialog" closedBy="any">
+		<h3>Legg til deltaker</h3>
+		@formsubmission.PuljeAssignmentSearch(db, logger, pulje)
+		<button
+			class="btn btn--outline"
+			type="button"
+			data-on:click="document.getElementById('puljefordeling-assign-dialog').close()"
+		>Lukk</button>
+	</dialog>
 }
 
 templ puljeStatusToggles(pulje models.PuljeRow) {
@@ -406,7 +492,7 @@ templ puljeStatusToggles(pulje models.PuljeRow) {
 	</div>
 }
 
-templ puljeEventBox(ev puljefordeling.EmulatedEvent) {
+templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
 	<div class="pulje-event">
 		<div class="pulje-event-top">
 			<h3>{ ev.Title }</h3>
@@ -421,14 +507,27 @@ templ puljeEventBox(ev puljefordeling.EmulatedEvent) {
 		if len(ev.AssignedPlayers) > 0 {
 			<ul class="pulje-players">
 				for _, pl := range ev.AssignedPlayers {
-					<li class={ templ.KV("moved", pl.Moved) }>
+					<li class={ templ.KV("moved", pl.Moved), templ.KV("manual", pl.Manual) }>
 						<span class="pulje-emoji">{ pl.Level.Emoji() }</span>
 						<span class={ templ.KV("pulje-dm", pl.IsDM) }>{ pl.Name }</span>
+						if pl.Manual {
+							<button
+								type="button"
+								class="pulje-remove"
+								title="Fjern manuell plassering"
+								data-on:click={ fmt.Sprintf("@delete('/admin/api/puljefordeling/%s/%s/%d')", string(pulje), ev.EventID, pl.BillettholderID) }
+							>×</button>
+						}
 					</li>
 				}
 			</ul>
 		} else {
 			<p class="pulje-empty">Ingen deltakere</p>
 		}
+		<button
+			type="button"
+			class="pulje-add"
+			data-on:click={ fmt.Sprintf("$assignmentEventId = '%s'; $assignmentPuljeId = '%s'; document.getElementById('puljefordeling-assign-dialog').showModal()", ev.EventID, string(pulje)) }
+		>+ Legg til deltaker</button>
 	</div>
 }

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -147,7 +147,13 @@ templ puljefordelingIndex(db *sql.DB, logger *slog.Logger, current models.Pulje)
 		{Name: "Admin", Url: "/admin/"},
 		{Name: "Puljefordeling", Url: ""},
 	})
-	<div class="page-content-container flex flex-col">
+	<div
+		class="page-content-container flex flex-col"
+		data-signals:assignment-event-id="''"
+		data-signals:assignment-pulje-id="''"
+		data-signals:assignment-billettholder-id="0"
+		data-signals:clear-input="0"
+	>
 		<style>
             .tabs {
                 display: flex;
@@ -199,6 +205,7 @@ templ puljefordelingIndex(db *sql.DB, logger *slog.Logger, current models.Pulje)
 			}
 		</div>
 		@PuljefordelingTabContent(db, logger, current)
+		@puljeAssignDialog(db, logger, current)
 	</div>
 }
 
@@ -387,10 +394,6 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		class="rooms-section"
 		data-init={ live.DatastarInit(fmt.Sprintf("/admin/api/puljefordeling/%s", pulje)) }
 		data-signals:pulje-status={ fmt.Sprintf("'%s'", string(row.Status)) }
-		data-signals:assignment-event-id="''"
-		data-signals:assignment-pulje-id="''"
-		data-signals:assignment-billettholder-id="0"
-		data-signals:clear-input="0"
 	>
 		<div class="pulje-tab-header">
 			<div>
@@ -435,7 +438,6 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 					<p>{ strings.Join(result.Unassigned, ", ") }</p>
 				</div>
 			}
-			@puljeAssignDialog(db, logger, pulje)
 		}
 	</section>
 }

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -450,8 +450,9 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		</div>
 		<div class="pulje-legend">
 			<p>🔥 Veldig interessert · 👍 Middels · 🤷 Litt</p>
+			<p><span class="legend-dm-name">Turkis navn</span> = Spilleder</p>
 			<p>
-				<span class="legend-dm-name">Turkis navn</span> = Spilleder · <span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
+				<span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
 			</p>
 		</div>
 		if emErr != nil {

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -302,6 +302,13 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             color: var(--color-text-soft);
             font-style: italic;
         }
+        .pulje-gm-missing {
+            color: var(--color-text-warning, #e0a030);
+            font-style: italic;
+        }
+        .pulje-event.missing-dm {
+            border-color: var(--color-text-warning, #e0a030);
+        }
         .pulje-badge {
             align-self: flex-start;
             padding: 0 var(--spacing-2x);
@@ -495,13 +502,15 @@ templ puljeStatusToggles(pulje models.PuljeRow) {
 }
 
 templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent) {
-	<div class="pulje-event">
+	<div class={ "pulje-event", templ.KV("missing-dm", ev.GMName == "") }>
 		<div class="pulje-event-top">
 			<h3>{ ev.Title }</h3>
 			<span class="pulje-cap">{ fmt.Sprintf("%d / %d", len(ev.AssignedPlayers), ev.Capacity) }</span>
 		</div>
 		if ev.GMName != "" {
 			<p class="pulje-gm">Spilleder: { ev.GMName }</p>
+		} else {
+			<p class="pulje-gm-missing">Mangler spilleder</p>
 		}
 		if ev.Undersubscribed {
 			<span class="pulje-badge">Få deltakere</span>

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -1,0 +1,102 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/testutil"
+	"github.com/Regncon/conorganizer/testutil/templtest"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestPuljefordelingRemoveManualSeatRoute_DeletesPin(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route")
+	router := chi.NewRouter()
+	puljefordelingRoute(router, db, &live.Manager{}, logger)
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/FredagKveld/evA/1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204 No Content, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players WHERE event_id='evA' AND billettholder_id=1 AND source='manual'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count manual seats: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("manual seat should be deleted, still found %d", n)
+	}
+}
+
+func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_tab_interactive")
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	// Kari is a manual pin → her tile must offer a × that removes her seat.
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
+
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, fredag))
+	html, err := doc.Html()
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+
+	wants := []string{
+		// The shared picker dialog and custom search element are present.
+		"puljefordeling-assign-dialog",
+		"admin-billettholder-search",
+		// The × on Kari's manual tile deletes her manual seat.
+		"/admin/api/puljefordeling/FredagKveld/evA/1",
+	}
+	for _, want := range wants {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered tab should contain %q", want)
+		}
+	}
+
+	// The + button opens the dialog scoped to this event (attribute decoded).
+	addClick := doc.Find(".pulje-add").AttrOr("data-on:click", "")
+	if !strings.Contains(addClick, "$assignmentEventId = 'evA'") {
+		t.Errorf("+ button should set assignmentEventId to the event; got %q", addClick)
+	}
+}
+
+func TestPuljefordelingRemoveManualSeatRoute_RejectsInvalidPulje(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route_invalid")
+	router := chi.NewRouter()
+	puljefordelingRoute(router, db, &live.Manager{}, logger)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/NotAPulje/evA/1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid pulje should be rejected with 400, got %d", rec.Code)
+	}
+}

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -3,11 +3,14 @@ package admin
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/Regncon/conorganizer/components/formsubmission"
 	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/service/puljefordeling"
 	"github.com/Regncon/conorganizer/testutil"
 	"github.com/Regncon/conorganizer/testutil/templtest"
 	"github.com/go-chi/chi/v5"
@@ -84,6 +87,51 @@ func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) 
 	addClick := doc.Find(".pulje-add").AttrOr("data-on:click", "")
 	if !strings.Contains(addClick, "$assignmentEventId = 'evA'") {
 		t.Errorf("+ button should set assignmentEventId to the event; got %q", addClick)
+	}
+}
+
+func TestAddFirstChoiceThenEmulate_PinsAddedPlayer(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_add_then_pin")
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+
+	// Add Kari through the real picker add path (the + button's endpoint).
+	if err := formsubmission.AddPlayersFirstChoice(1, "evA", string(fredag), db, logger); err != nil {
+		t.Fatalf("AddPlayersFirstChoice: %v", err)
+	}
+
+	// A subsequent emulation must pin her into evA, marked as a manual placement.
+	em, err := puljefordeling.EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+	var evA puljefordeling.EmulatedEvent
+	for _, p := range em.Puljer {
+		if p.PuljeID == fredag {
+			for _, e := range p.Events {
+				if e.EventID == "evA" {
+					evA = e
+				}
+			}
+		}
+	}
+	names := make([]string, len(evA.AssignedPlayers))
+	for i, ap := range evA.AssignedPlayers {
+		names[i] = ap.Name
+	}
+	if !slices.Contains(names, "Kari Nordmann") {
+		t.Fatalf("added player should be pinned into evA, got %v", names)
+	}
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Kari Nordmann" && !ap.Manual {
+			t.Errorf("added player should be marked as a manual placement")
+		}
 	}
 }
 

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -70,23 +70,34 @@ func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) 
 		t.Fatalf("render html: %v", err)
 	}
 
-	wants := []string{
-		// The shared picker dialog and custom search element are present.
-		"puljefordeling-assign-dialog",
-		"admin-billettholder-search",
-		// The × on Kari's manual tile deletes her manual seat.
-		"/admin/api/puljefordeling/FredagKveld/evA/1",
-	}
-	for _, want := range wants {
-		if !strings.Contains(html, want) {
-			t.Errorf("rendered tab should contain %q", want)
-		}
+	// The × on Kari's manual tile deletes her manual seat.
+	if !strings.Contains(html, "/admin/api/puljefordeling/FredagKveld/evA/1") {
+		t.Errorf("manual tile should contain the remove URL")
 	}
 
 	// The + button opens the dialog scoped to this event (attribute decoded).
 	addClick := doc.Find(".pulje-add").AttrOr("data-on:click", "")
 	if !strings.Contains(addClick, "$assignmentEventId = 'evA'") {
 		t.Errorf("+ button should set assignmentEventId to the event; got %q", addClick)
+	}
+}
+
+// The picker is a modal dialog. If it renders inside the SSE-updated section
+// (#puljefordeling-tab), every add re-renders the section and orphans the open
+// modal's backdrop, locking the page. It must live in the stable outer wrapper.
+func TestPuljefordelingIndex_DialogRendersOutsideLiveRegion(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_dialog_placement")
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+
+	doc := templtest.Render(t, puljefordelingIndex(db, logger, fredag))
+
+	if got := doc.Find("#puljefordeling-assign-dialog").Length(); got != 1 {
+		t.Fatalf("expected exactly one assign dialog, got %d", got)
+	}
+	if got := doc.Find("#puljefordeling-tab #puljefordeling-assign-dialog").Length(); got != 0 {
+		t.Errorf("assign dialog must NOT be inside the live #puljefordeling-tab section (orphans the modal backdrop on SSE re-render)")
 	}
 }
 

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -146,6 +146,39 @@ func TestAddFirstChoiceThenEmulate_PinsAddedPlayer(t *testing.T) {
 	}
 }
 
+func TestPuljefordelingRemoveManualSeatRoute_RejectsWhenPublished(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_published")
+	router := chi.NewRouter()
+	puljefordelingRoute(router, db, &live.Manager{}, logger)
+
+	const fredag = models.PuljeFredagKveld
+	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusCompleted, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(fredag))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/FredagKveld/evA/1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("removing from a published pulje should be rejected with 409, got %d", rec.Code)
+	}
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players WHERE event_id='evA' AND billettholder_id=1 AND source='manual'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count manual seats: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("manual seat must survive a rejected remove, found %d", n)
+	}
+}
+
 func TestPuljefordelingRemoveManualSeatRoute_RejectsInvalidPulje(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route_invalid")
 	router := chi.NewRouter()

--- a/pages/admin/puljefordeling_tab_test.go
+++ b/pages/admin/puljefordeling_tab_test.go
@@ -114,6 +114,30 @@ func TestPuljefordelingTabContent_ShowsRunningUnsatisfiedCount(t *testing.T) {
 	}
 }
 
+func TestPuljefordelingTabContent_WarnsWhenEventHasNoDm(t *testing.T) {
+	bdd.Behavior(t, bdd.BDD{
+		Given: "Gitt et arrangement i en pulje uten tildelt spilleder.",
+		When:  "Når puljefordeling-fanen rendres.",
+		Then:  "Så skal arrangementet markeres som at det mangler spilleder.",
+	})
+
+	// Given: an event in the pulje with no GM assigned.
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_missing_dm")
+	seedTabPulje(t, db, models.PuljeFredagKveld, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(models.PuljeFredagKveld))
+
+	// When
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	text := strings.Join(templtest.CollectTexts(doc, "#puljefordeling-tab"), " ")
+
+	// Then
+	if !strings.Contains(text, "Mangler spilleder") {
+		t.Fatalf("event without a DM should be flagged 'Mangler spilleder'\nactual text: %s", text)
+	}
+}
+
 func TestPuljeStatusToggles_ReflectLockedAndCompletedState(t *testing.T) {
 	bdd.Behavior(t, bdd.BDD{
 		Given: "Gitt en pulje som er publisert (Completed).",

--- a/pages/admin/puljefordeling_tab_test.go
+++ b/pages/admin/puljefordeling_tab_test.go
@@ -138,6 +138,33 @@ func TestPuljefordelingTabContent_WarnsWhenEventHasNoDm(t *testing.T) {
 	}
 }
 
+func TestPuljefordelingTabContent_PublishedHidesAssignmentControls(t *testing.T) {
+	bdd.Behavior(t, bdd.BDD{
+		Given: "Gitt en publisert (Completed) pulje med en manuell plassering.",
+		When:  "Når puljefordeling-fanen rendres.",
+		Then:  "Så skal verken «legg til» eller «fjern»-kontrollene vises.",
+	})
+
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_published_readonly")
+	seedTabPulje(t, db, models.PuljeFredagKveld, "Fredag Kveld", models.PuljeStatusCompleted, "2026-01-01 18:00")
+	testutil.MustExec(t, db, `INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		VALUES ('evA','Alpha','','','','','',4)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(models.PuljeFredagKveld))
+	testutil.MustExec(t, db, `INSERT INTO billettholdere (id, first_name, last_name, ticket_type_id, ticket_type, order_id, ticket_id)
+		VALUES (1,'Kari','Nordmann',0,'',0,1)`)
+	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		VALUES ('evA',?,1,'Player','manual')`, string(models.PuljeFredagKveld))
+
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+
+	if n := doc.Find(".pulje-add").Length(); n != 0 {
+		t.Errorf("published pulje must not show the add button, found %d", n)
+	}
+	if n := doc.Find(".pulje-remove").Length(); n != 0 {
+		t.Errorf("published pulje must not show remove controls, found %d", n)
+	}
+}
+
 func TestPuljeStatusToggles_ReflectLockedAndCompletedState(t *testing.T) {
 	bdd.Behavior(t, bdd.BDD{
 		Given: "Gitt en pulje som er publisert (Completed).",

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -18,11 +18,12 @@ import (
 // show how much they wanted this game, whether they carry the DM bump, and
 // whether they were bumped off a stronger preference to make room for others.
 type AssignedPlayer struct {
-	Name   string
-	IsDM   bool                 // runs at least one game in the weekend (DM bump)
-	Level  models.InterestLevel // their interest in the game they got
-	Moved  bool                 // relocated off a higher-scoring event by the solver to make room for others
-	Manual bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
+	BillettholderID int // participant id, for manual-seat removal from the UI
+	Name            string
+	IsDM            bool                 // runs at least one game in the weekend (DM bump)
+	Level           models.InterestLevel // their interest in the game they got
+	Moved           bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Manual          bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
 }
 
 // Seat sources recorded on relation_events_players. Manual seats are admin pins
@@ -211,7 +212,7 @@ func assignedPlayers(
 			out = append(out, AssignedPlayer{Name: id})
 			continue
 		}
-		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
+		ap := AssignedPlayer{BillettholderID: bh, Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
 		if byPulje, ok := prefs[bh]; ok {
 			got := byPulje[puljeID][eventID]
 			ap.Level = models.InterestLevelFromScore(int(got))

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -18,11 +18,19 @@ import (
 // show how much they wanted this game, whether they carry the DM bump, and
 // whether they were bumped off a stronger preference to make room for others.
 type AssignedPlayer struct {
-	Name  string
-	IsDM  bool                 // runs at least one game in the weekend (DM bump)
-	Level models.InterestLevel // their interest in the game they got
-	Moved bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Name   string
+	IsDM   bool                 // runs at least one game in the weekend (DM bump)
+	Level  models.InterestLevel // their interest in the game they got
+	Moved  bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Manual bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
 }
+
+// Seat sources recorded on relation_events_players. Manual seats are admin pins
+// the solver must honour; solver seats are produced by a committed distribution.
+const (
+	SourceManual = "manual"
+	SourceSolver = "solver"
+)
 
 // EmulatedEvent is the proposed seating for a single event within a pulje.
 type EmulatedEvent struct {
@@ -85,6 +93,10 @@ func EmulateSeatings(db *sql.DB) (Emulation, error) {
 	if err != nil {
 		return Emulation{}, err
 	}
+	pins, err := loadManualPins(db) // pulje -> playerID -> eventID (admin manual seats)
+	if err != nil {
+		return Emulation{}, err
+	}
 
 	// Build the solver's Weekend in chronological pulje order.
 	weekend := smodel.Weekend{Slots: make([]smodel.Slot, 0, len(puljer))}
@@ -123,8 +135,8 @@ func EmulateSeatings(db *sql.DB) (Emulation, error) {
 	emulation := Emulation{Year: year, PlayerCount: len(players)}
 	for i, slot := range weekend.Slots {
 		pulje := puljer[i]
-		res := state.SolveSlot(slot, players)
-		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet))
+		res := state.SolveSlotFixed(slot, players, pins[pulje.ID])
+		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet, pins[pulje.ID]))
 	}
 	emulation.SatisfiedTotal = state.SatisfiedCount()
 
@@ -140,6 +152,7 @@ func shapePulje(
 	names map[int]string,
 	prefs map[int]map[string]map[string]smodel.Score,
 	dmSet map[int]bool,
+	manual map[string]string,
 ) EmulatedPulje {
 	under := make(map[string]bool, len(res.UndersubscribedEvents))
 	for _, eid := range res.UndersubscribedEvents {
@@ -164,7 +177,7 @@ func shapePulje(
 			EventID:         ev.ID,
 			Title:           ev.Name,
 			Capacity:        ev.Capacity,
-			AssignedPlayers: assignedPlayers(res.Assignments[ev.ID], ev.ID, string(pulje.ID), names, prefs, dmSet, moved),
+			AssignedPlayers: assignedPlayers(res.Assignments[ev.ID], ev.ID, string(pulje.ID), names, prefs, dmSet, moved, manual),
 			Undersubscribed: under[ev.ID],
 		}
 		if gmID, ok := gms[eventPuljeKey(ev.ID, pulje.ID)]; ok {
@@ -186,6 +199,7 @@ func assignedPlayers(
 	prefs map[int]map[string]map[string]smodel.Score,
 	dmSet map[int]bool,
 	moved map[string]bool,
+	manual map[string]string,
 ) []AssignedPlayer {
 	if len(ids) == 0 {
 		return nil
@@ -197,7 +211,7 @@ func assignedPlayers(
 			out = append(out, AssignedPlayer{Name: id})
 			continue
 		}
-		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id]}
+		ap := AssignedPlayer{Name: names[bh], IsDM: dmSet[bh], Moved: moved[id], Manual: manual[id] == eventID}
 		if byPulje, ok := prefs[bh]; ok {
 			got := byPulje[puljeID][eventID]
 			ap.Level = models.InterestLevelFromScore(int(got))
@@ -258,6 +272,38 @@ func loadEligibleEvents(db *sql.DB) (map[models.Pulje]map[string]eligibleEvent, 
 			out[pulje] = make(map[string]eligibleEvent)
 		}
 		out[pulje][eventID] = eligibleEvent{title: title, capacity: maxPlayers}
+	}
+	return out, rows.Err()
+}
+
+// loadManualPins returns the admin-pinned player seats keyed by pulje, then by
+// solver player ID (the billettholder ID as a string) → event ID. These are
+// fed to the solver as fixed placements so a manually-added player is reserved
+// into their event regardless of expressed interest.
+func loadManualPins(db *sql.DB) (map[models.Pulje]map[string]string, error) {
+	const query = `
+		SELECT pulje_id, event_id, billettholder_id
+		FROM relation_events_players
+		WHERE source = ? AND role = ?
+	`
+	rows, err := db.Query(query, SourceManual, models.EventPlayerRolePlayer)
+	if err != nil {
+		return nil, fmt.Errorf("query manual pins: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[models.Pulje]map[string]string)
+	for rows.Next() {
+		var pulje models.Pulje
+		var eventID string
+		var bhID int
+		if err := rows.Scan(&pulje, &eventID, &bhID); err != nil {
+			return nil, fmt.Errorf("scan manual pin row: %w", err)
+		}
+		if out[pulje] == nil {
+			out[pulje] = make(map[string]string)
+		}
+		out[pulje][strconv.Itoa(bhID)] = eventID
 	}
 	return out, rows.Err()
 }

--- a/service/puljefordeling/manual_pins.go
+++ b/service/puljefordeling/manual_pins.go
@@ -1,0 +1,25 @@
+package puljefordeling
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Regncon/conorganizer/models"
+)
+
+// RemoveManualSeat deletes an admin-pinned player seat (source='manual',
+// role='Player') for the given pulje/event/participant. It only removes manual
+// player pins — solver seats and GM rows are left untouched. Removing the pin
+// does not touch the player's interest, so a later emulation may still seat them
+// in the same event by simulation (now as a non-manual placement).
+func RemoveManualSeat(db *sql.DB, pulje models.Pulje, eventID string, billettholderID int) error {
+	const query = `
+		DELETE FROM relation_events_players
+		WHERE event_id = ? AND pulje_id = ? AND billettholder_id = ?
+		  AND source = ? AND role = ?
+	`
+	if _, err := db.Exec(query, eventID, string(pulje), billettholderID, SourceManual, models.EventPlayerRolePlayer); err != nil {
+		return fmt.Errorf("remove manual seat (pulje=%s event=%s bh=%d): %w", pulje, eventID, billettholderID, err)
+	}
+	return nil
+}

--- a/service/puljefordeling/manual_pins_test.go
+++ b/service/puljefordeling/manual_pins_test.go
@@ -1,0 +1,210 @@
+package puljefordeling
+
+import (
+	"database/sql"
+	"slices"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func TestEmulateSeatings_ManualPinSeatsPlayerWithoutInterest(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+
+	// Kari expressed NO interest in evA. A manual seat (source='manual') must
+	// still pin her into evA when the distribution is emulated.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	evA, ok := findEvent(em.Puljer[0], "evA")
+	if !ok {
+		t.Fatal("evA missing from result")
+	}
+	if !slices.Contains(playerNames(evA.AssignedPlayers), "Kari Nordmann") {
+		t.Fatalf("manual pin should seat Kari in evA, got %v", playerNames(evA.AssignedPlayers))
+	}
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Kari Nordmann" && !ap.Manual {
+			t.Errorf("Kari was added manually and should be marked Manual")
+		}
+	}
+}
+
+func manualSeatCount(t *testing.T, db interface {
+	QueryRow(string, ...any) *sql.Row
+}, eventID string, pulje models.Pulje, bhID int) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players
+		 WHERE event_id = ? AND pulje_id = ? AND billettholder_id = ? AND source = 'manual' AND role = 'Player'`,
+		eventID, string(pulje), bhID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count manual seats: %v", err)
+	}
+	return n
+}
+
+func TestRemoveManualSeat_DeletesManualPlayerSeat(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "remove_manual_seat")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	if err := RemoveManualSeat(db, fredag, "evA", 1); err != nil {
+		t.Fatalf("RemoveManualSeat: %v", err)
+	}
+
+	if got := manualSeatCount(t, db, "evA", fredag, 1); got != 0 {
+		t.Fatalf("manual seat should be deleted, still found %d", got)
+	}
+}
+
+func TestRemoveManualSeat_LeavesSolverSeatIntact(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "remove_manual_seat_guard")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	seedEvent(t, db, "evA", "Alpha", 4, fredag)
+	seedParticipant(t, db, 1, "Kari", "Nordmann")
+	// A solver-sourced seat must not be removable through the manual-remove path.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'solver')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed solver seat: %v", err)
+	}
+
+	if err := RemoveManualSeat(db, fredag, "evA", 1); err != nil {
+		t.Fatalf("RemoveManualSeat: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM relation_events_players WHERE source = 'solver'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count solver seats: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("solver seat must remain, found %d", n)
+	}
+}
+
+func TestEmulateSeatings_PinnedPlayerCountsAsSatisfiedAndScored(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin_satisfied")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	// One seat in evA; two participants want it as their top choice.
+	seedEvent(t, db, "evA", "Alpha", 1, fredag)
+	seedParticipant(t, db, 1, "Pin", "Ned")
+	seedParticipant(t, db, 2, "Loser", "Out")
+	seedInterest(t, db, 1, "evA", fredag, models.InterestLevelHigh)
+	seedInterest(t, db, 2, "evA", fredag, models.InterestLevelHigh)
+
+	// Pin the player who DID want evA (top choice) into the single seat.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	p := em.Puljer[0]
+	// The pinned player wanted evA as a top choice, so pinning them there must
+	// count as a newly-satisfied top choice and contribute their score.
+	if p.NewlySatisfied != 1 {
+		t.Errorf("pinned top-choice player should be newly satisfied: want 1, got %d", p.NewlySatisfied)
+	}
+	if em.SatisfiedTotal != 1 {
+		t.Errorf("satisfied total: want 1, got %d", em.SatisfiedTotal)
+	}
+	if p.TotalScore < int(models.InterestLevelHigh.Score()) {
+		t.Errorf("pinned top-choice player should contribute their score; total score too low: %d", p.TotalScore)
+	}
+
+	evA, _ := findEvent(p, "evA")
+	for _, ap := range evA.AssignedPlayers {
+		if ap.Name == "Pin Ned" {
+			if !ap.Manual {
+				t.Errorf("pinned player should be marked Manual")
+			}
+			if ap.Level != models.InterestLevelHigh {
+				t.Errorf("pinned player's surfaced interest level: want High, got %q", ap.Level)
+			}
+		}
+	}
+}
+
+func TestEmulateSeatings_ManualPinReservesSeatUnderContention(t *testing.T) {
+	db, _ := testutil.CreateTestDBAndLogger(t, "emulate_manual_pin_contention")
+
+	const fredag = models.PuljeFredagKveld
+	seedPulje(t, db, fredag, "Fredag Kveld", "2026-09-04T18:00:00Z")
+	// Single seat in evA; two highly-interested regulars compete for it.
+	seedEvent(t, db, "evA", "Alpha", 1, fredag)
+	seedParticipant(t, db, 1, "Pin", "Ned")
+	seedParticipant(t, db, 2, "Eager", "One")
+	seedParticipant(t, db, 3, "Eager", "Two")
+	seedInterest(t, db, 2, "evA", fredag, models.InterestLevelHigh)
+	seedInterest(t, db, 3, "evA", fredag, models.InterestLevelHigh)
+
+	// Admin pins Pin Ned into the single evA seat; the solver must honour it and
+	// leave the eager regulars without that seat.
+	if _, err := db.Exec(
+		`INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
+		 VALUES (?, ?, ?, 'Player', 'manual')`,
+		"evA", string(fredag), 1,
+	); err != nil {
+		t.Fatalf("seed manual seat: %v", err)
+	}
+
+	em, err := EmulateSeatings(db)
+	if err != nil {
+		t.Fatalf("EmulateSeatings: %v", err)
+	}
+
+	evA, ok := findEvent(em.Puljer[0], "evA")
+	if !ok {
+		t.Fatal("evA missing from result")
+	}
+	names := playerNames(evA.AssignedPlayers)
+	if !slices.Contains(names, "Pin Ned") {
+		t.Fatalf("pinned player must keep the contested seat, got %v", names)
+	}
+	if len(evA.AssignedPlayers) != 1 {
+		t.Fatalf("evA capacity is 1 and a pin fills it; want 1 seated, got %v", names)
+	}
+}

--- a/service/puljefordeling/manual_pins_test.go
+++ b/service/puljefordeling/manual_pins_test.go
@@ -40,8 +40,13 @@ func TestEmulateSeatings_ManualPinSeatsPlayerWithoutInterest(t *testing.T) {
 		t.Fatalf("manual pin should seat Kari in evA, got %v", playerNames(evA.AssignedPlayers))
 	}
 	for _, ap := range evA.AssignedPlayers {
-		if ap.Name == "Kari Nordmann" && !ap.Manual {
-			t.Errorf("Kari was added manually and should be marked Manual")
+		if ap.Name == "Kari Nordmann" {
+			if !ap.Manual {
+				t.Errorf("Kari was added manually and should be marked Manual")
+			}
+			if ap.BillettholderID != 1 {
+				t.Errorf("assigned player should carry the billettholder id for removal: want 1, got %d", ap.BillettholderID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds interactive add/remove on the per-pulje tabbed view:

- **+** opens the shared picker to add a player/GM as a manual pin; the solver reserves that seat (honoured even with no interest, and under contention).
- Pinned players still count as satisfied and toward the score.
- **×** removes a manual pin (keeps interest, so the solver may re-seat).

Test-first; `go test ./...` and `golangci-lint` pass. Out of scope: rerun, lock-commit.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://464-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->