### PR TITLE
Restore drag-and-drop room assignment (#453 was orphaned from main)

### DIFF
--- a/pages/admin/rooms/rooms_assignment_page.templ
+++ b/pages/admin/rooms/rooms_assignment_page.templ
@@ -3,6 +3,7 @@ package rooms
 import (
 	"database/sql"
 	"fmt"
+	"github.com/Regncon/conorganizer/components/errorfeedback"
 	"github.com/Regncon/conorganizer/components/icons"
 	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/eventimage"
@@ -165,6 +166,10 @@ templ roomEventCard(event models.RoomEventPuljeSummary, eventImageDir *string) {
 		role="button"
 		href={ "/admin/approval/edit/" + event.EventID }
 		class="room-event"
+		draggable="true"
+		data-on:dragstart={ fmt.Sprintf("$draggedEventId = '%s'", event.EventID) }
+		data-on:dragend="$draggedEventId = ''; $dragOverRoom = 0"
+		data-class:is-dragging={ fmt.Sprintf("$draggedEventId === '%s'", event.EventID) }
 	>
 		<img
 			src={ imageBannerUrl }
@@ -175,9 +180,13 @@ templ roomEventCard(event models.RoomEventPuljeSummary, eventImageDir *string) {
 	</a>
 }
 
-templ roomPuljeContainer(room models.RoomByPulje, eventImageDir *string) {
+templ roomPuljeContainer(room models.RoomByPulje, pulje models.Pulje, eventImageDir *string) {
 	<div
 		class="room"
+		data-on:dragover__prevent={ fmt.Sprintf("$dragOverRoom = %d", room.ID) }
+		data-on:drop__prevent={ fmt.Sprintf("$dragOverRoom = 0; $draggedEventId && @post('/admin/rooms/api/assignment/%s/' + $draggedEventId + '/%d')", string(pulje), room.ID) }
+		data-class:is-drag-over={ fmt.Sprintf("$dragOverRoom === %d", room.ID) }
+		{ errorfeedback.Attrs("room-assignment", "Klarte ikkje å tildele rommet. Prøv igjen.")... }
 		style={ templ.KV("background-color: var(--bg-surface)", room.IsDisabled),
         templ.KV("border-color: var(--color-error)", room.IsDisabled && len(room.AssignedEventsID)>0) }
 	>
@@ -241,13 +250,13 @@ templ roomPuljeContainer(room models.RoomByPulje, eventImageDir *string) {
 	</div>
 }
 
-templ floorPuljeContainer(floor int, rooms []models.RoomByPulje, eventImageDir *string) {
+templ floorPuljeContainer(floor int, rooms []models.RoomByPulje, pulje models.Pulje, eventImageDir *string) {
 	for index, room := range rooms {
 		if !room.IsDisabled || len(room.AssignedEventsID) > 0 {
 			if index == 0 {
 				<h2>{ floor }. Etg</h2>
 			}
-			@roomPuljeContainer(room, eventImageDir)
+			@roomPuljeContainer(room, pulje, eventImageDir)
 		}
 	}
 }
@@ -297,6 +306,10 @@ templ RoomsAssignmentPage(db *sql.DB, logger *slog.Logger, pulje models.Pulje, e
 
         .room:hover {
             border-color: var(--bg-item-border-hover);
+        }
+        .room.is-drag-over {
+            border-color: var(--color-primary);
+            background-color: var(--bg-item-hover);
         }
 
         @media screen and (width > 1200px) {
@@ -378,13 +391,26 @@ templ RoomsAssignmentPage(db *sql.DB, logger *slog.Logger, pulje models.Pulje, e
         .room-event:hover {
             border-color: var(--color-primary);
         }
+        .room-event[draggable="true"] {
+            cursor: grab;
+        }
+        .room-event.is-dragging {
+            opacity: 0.5;
+        }
 	</style>
 	@assignEventModal(db, logger, pulje, eventImageDir)
 	@RoomsAssignmentPageContent(db, logger, pulje, eventImageDir)
 }
 
 templ RoomsAssignmentPageContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje, eventImageDir *string) {
-	<section id="room-assignment" class="rooms-section" data-init={ live.DatastarInit(fmt.Sprintf("/admin/rooms/api/assignment/%s", pulje)) }>
+	<section
+		id="room-assignment"
+		class="rooms-section"
+		data-init={ live.DatastarInit(fmt.Sprintf("/admin/rooms/api/assignment/%s", pulje)) }
+		data-signals:dragged-event-id="''"
+		data-signals:drag-over-room="0"
+	>
+		@errorfeedback.RenderMessage("room-assignment")
 		{{ events := getEventInPulje(db, logger, pulje, true) }}
 		if len(events) > 0 {
 			<h2>{ len(events) } Eventer i pulje uten tildelt rom</h2>
@@ -394,6 +420,9 @@ templ RoomsAssignmentPageContent(db *sql.DB, logger *slog.Logger, pulje models.P
 						role="button"
 						href={ "/admin/approval/edit/" + event.EventID }
 						class="btn btn--outline"
+						draggable="true"
+						data-on:dragstart={ fmt.Sprintf("$draggedEventId = '%s'", event.EventID) }
+						data-on:dragend="$draggedEventId = ''; $dragOverRoom = 0"
 					>{ event.Title } ({ event.MaxPlayers })</a>
 				}
 			</div>
@@ -403,7 +432,7 @@ templ RoomsAssignmentPageContent(db *sql.DB, logger *slog.Logger, pulje models.P
 		if len(floors) > 0 {
 			<div class="rooms-container">
 				for _, floorGroup := range floors {
-					@floorPuljeContainer(floorGroup.Floor, floorGroup.Rooms, eventImageDir)
+					@floorPuljeContainer(floorGroup.Floor, floorGroup.Rooms, pulje, eventImageDir)
 				}
 			</div>
 		} else {

--- a/pages/admin/rooms/rooms_page_test.go
+++ b/pages/admin/rooms/rooms_page_test.go
@@ -102,6 +102,23 @@ func TestRoomsAssignmentPageContent_RendersMissingRoomEventsAndAssignedRooms(t *
 			t.Fatalf("expected room assignment text to contain %q\nactual text: %s", expectedTextPart, actualText)
 		}
 	}
+
+	// Drag-and-drop is wired with Datastar: drop targets @post via the
+	// $draggedEventId signal set on dragstart — no custom fetch or headers.
+	roomDropTarget := doc.Find(".room")
+	if roomDropTarget.Length() == 0 {
+		t.Fatal("expected a room drop target")
+	}
+	wantDrop := "@post('/admin/rooms/api/assignment/FredagKveld/' + $draggedEventId + '/1')"
+	if got := roomDropTarget.AttrOr("data-on:drop__prevent", ""); !strings.Contains(got, wantDrop) {
+		t.Fatalf("room drop handler mismatch\nexpected to contain: %s\nactual:              %s", wantDrop, got)
+	}
+	if got := doc.Find(`.room-event[draggable="true"]`).AttrOr("data-on:dragstart", ""); got != "$draggedEventId = 'assigned-room-event'" {
+		t.Fatalf("assigned room event card should set the dragged signal on dragstart\nactual: %s", got)
+	}
+	if got := doc.Find(`.event-list a[draggable="true"]`).AttrOr("data-on:dragstart", ""); got != "$draggedEventId = 'missing-room-event'" {
+		t.Fatalf("missing-room event link should set the dragged signal on dragstart\nactual: %s", got)
+	}
 }
 
 func TestCalculatePopulation_CountsPlayersAndGMs(t *testing.T) {


### PR DESCRIPTION
#453 ("drag-and-drop event assignment") shows as **merged**, but its merge commit (`bb7e1700`) is **not an ancestor of `main`** — main's history was rewritten/force-pushed upstream after the merge, orphaning it. As a result the rooms assignment page silently reverted to the old modal-only version (`git log -S 'draggable="true"'` on main finds nothing).

This re-applies #453's diff verbatim: Datastar-driven drag-and-drop — `draggable="true"` cards setting `$draggedEventId` on `dragstart`, drop targets `@post`-ing the assignment on `drop__prevent`. No custom JS.

Two files, exactly as #453: `rooms_assignment_page.templ` + `rooms_page_test.go`.

`go test ./...` and `golangci-lint` pass.

> ⚠️ Worth checking how main got force-pushed — #453/#454 may not be the only commits dropped.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://465-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->