### PR TITLE
Puljeoppsett: drag games into slots board

### DIFF
--- a/components/formsubmission/form_body.templ
+++ b/components/formsubmission/form_body.templ
@@ -79,7 +79,10 @@ func updateEventPuljePublishedWithAudit(ctx context.Context, db *sql.DB, logger 
 	return nil
 }
 
-func updateEventPuljeMembershipWithAudit(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, isInPulje bool) error {
+// SetEventInPulje upserts whether an event belongs to a pulje (is_in_pulje),
+// resets is_published, and stamps updated_by_id. Shared by the per-event form
+// and the puljeoppsett board. Idempotent.
+func SetEventInPulje(ctx context.Context, db *sql.DB, logger *slog.Logger, eventID string, puljeID string, isInPulje bool) error {
 	updatedByID, err := currentUserDBID(ctx, db, logger)
 	if err != nil {
 		return err

--- a/components/formsubmission/puljefordeling.templ
+++ b/components/formsubmission/puljefordeling.templ
@@ -123,7 +123,7 @@ func UpdateEventInPulje(eventRouter chi.Router, db *sql.DB, liveManager *live.Ma
 				return
 			}
 
-			if err := updateEventPuljeMembershipWithAudit(r.Context(), db, logger, eventID, puljeId, isInPulje); err != nil {
+			if err := SetEventInPulje(r.Context(), db, logger, eventID, puljeId, isInPulje); err != nil {
 				logger.Error(fmt.Errorf("failed to upsert relation_event_puljer for event %s and pulje %s: %w", eventID, puljeId, err).Error())
 				http.Error(w, "Klarte ikkje å oppdatere arrangementet i puljen", http.StatusInternalServerError)
 				return

--- a/components/formsubmission/set_event_in_pulje_test.go
+++ b/components/formsubmission/set_event_in_pulje_test.go
@@ -1,0 +1,44 @@
+package formsubmission
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/service/authctx"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func TestSetEventInPulje_AddsThenRemovesMembership(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "set_event_in_pulje")
+	testutil.MustExec(t, db,
+		`INSERT INTO users (id, external_id, email, is_admin) VALUES (42, 'ext-42', 'admin@x.no', 1)`)
+	testutil.MustExec(t, db,
+		`INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?, 'Fredag', 'Open', '2026-01-01 18:00', '2026-01-01 22:00')`,
+		string(models.PuljeFredagKveld))
+	testutil.MustExec(t, db,
+		`INSERT INTO events (id, title, intro, description, host_name, email, phone_number, max_players)
+		 VALUES ('e1', 'Spel', '', '', 'Ola', 'ola@x.no', '', 4)`)
+
+	ctx := authctx.WithUserToken(context.Background(), "ext-42", "admin@x.no")
+	if err := SetEventInPulje(ctx, db, logger, "e1", string(models.PuljeFredagKveld), true); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got := testutil.QueryInt(t, db,
+		`SELECT is_in_pulje FROM relation_event_puljer WHERE event_id='e1' AND pulje_id=?`,
+		string(models.PuljeFredagKveld))
+	if got != 1 {
+		t.Fatalf("after add is_in_pulje = %d, want 1", got)
+	}
+
+	// Idempotent + removal.
+	if err := SetEventInPulje(ctx, db, logger, "e1", string(models.PuljeFredagKveld), false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	got = testutil.QueryInt(t, db,
+		`SELECT is_in_pulje FROM relation_event_puljer WHERE event_id='e1' AND pulje_id=?`,
+		string(models.PuljeFredagKveld))
+	if got != 0 {
+		t.Fatalf("after remove is_in_pulje = %d, want 0", got)
+	}
+}

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -29,6 +29,7 @@ func SetupAdminRoute(router chi.Router, logger *slog.Logger, liveManager *live.M
 		adminLayoutRoute(adminRouter, db, logger)
 		puljefordelingStatusRoute(adminRouter, db, liveManager, logger)
 		puljefordelingRoute(adminRouter, db, liveManager, baseLogger)
+		puljeoppsettRoute(adminRouter, db, liveManager, baseLogger)
 		programPublishingRoute(adminRouter, db, liveManager, logger)
 		adminRouter.Get("/api/", func(w http.ResponseWriter, r *http.Request) {
 			liveManager.Stream(w, r, live.Page{

--- a/pages/admin/admin_page.templ
+++ b/pages/admin/admin_page.templ
@@ -69,6 +69,14 @@ templ adminPage(db *sql.DB) {
 					) {
 						<a role="button" href="/admin/puljefordeling/" class="btn btn--outline">Gå til puljefordeling</a>
 					}
+					@adminCard(
+						"Puljeoppsett",
+						"Dra spel inn i puljane og sjå kor mange spel, 18+ og nybegynnarvennlege kvar pulje har. Åtvarar om ein spelleiar har to spel i same pulje.",
+						"/static/call-to-action-avatar.webp",
+						"Schedule games into puljer",
+					) {
+						<a role="button" href="/admin/puljeoppsett/" class="btn btn--outline">Gå til puljeoppsett</a>
+					}
                     @adminCard(
 						"Administrer rom",
 						"Her kan du ligge til, modifisere og få en oversikt over tilgjengelige rom",

--- a/pages/admin/puljeoppsett.templ
+++ b/pages/admin/puljeoppsett.templ
@@ -1,0 +1,185 @@
+package admin
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/service/live"
+)
+
+templ scheduleBoardIndex(db *sql.DB, logger *slog.Logger) {
+	@components.Breadcrumbs([]components.BreadcrumbPath{
+		{Name: "Hjem", Url: "/"},
+		{Name: "Admin", Url: "/admin/"},
+		{Name: "Puljeoppsett", Url: ""},
+	})
+	<div class="page-content-container flex flex-col">
+		@scheduleBoardStyles()
+		@ScheduleBoardContent(db, logger)
+	</div>
+}
+
+templ ScheduleBoardContent(db *sql.DB, logger *slog.Logger) {
+	{{ board, err := buildScheduleBoard(db, logger) }}
+	<section
+		id="puljeoppsett-board"
+		class="rooms-section"
+		data-init={ live.DatastarInit("/admin/api/puljeoppsett") }
+		data-signals:dragged-event-id="''"
+		data-signals:drag-over-pulje="''"
+	>
+		if err != nil {
+			<p style="color: var(--color-error);">Klarte ikkje å byggje brettet: { err.Error() }</p>
+		} else {
+			if board.CollisionCount > 0 {
+				<p class="board-collision-summary">
+					⚠ { fmt.Sprintf("%d spelleiar-kollisjon(ar)", board.CollisionCount) }
+				</p>
+			}
+			<div class="board-columns">
+				@poolColumn(board.Pool)
+				for _, col := range board.Columns {
+					@slotColumn(col)
+				}
+			</div>
+		}
+	</section>
+}
+
+templ poolColumn(games []BoardGame) {
+	<div class="board-col board-col--pool">
+		<header class="board-col-head">
+			<h3>I ingen pulje</h3>
+			<p class="board-stats">{ fmt.Sprintf("%d spel", len(games)) }</p>
+		</header>
+		<div class="board-col-body">
+			for _, g := range games {
+				@gameCard(g, "", false)
+			}
+		</div>
+	</div>
+}
+
+templ slotColumn(col SlotColumn) {
+	<div
+		class="board-col"
+		data-on:dragover__prevent={ fmt.Sprintf("$draggedEventId && ($dragOverPulje = '%s')", string(col.Pulje.ID)) }
+		data-on:drop__prevent={ fmt.Sprintf("$dragOverPulje = ''; $draggedEventId && @put('/admin/api/puljeoppsett/' + $draggedEventId + '/%s/add')", string(col.Pulje.ID)) }
+		data-class:is-drag-over={ fmt.Sprintf("$dragOverPulje === '%s'", string(col.Pulje.ID)) }
+	>
+		<header class="board-col-head">
+			<h3>{ col.Pulje.Name } <span>({ col.Pulje.TimeRange() })</span></h3>
+			<p class="board-stats">
+				{ fmt.Sprintf("%d spel · %d 18+ · %d nyb.", col.Stats.Games, col.Stats.Adults, col.Stats.Beginner) }
+			</p>
+		</header>
+		if len(col.Collisions) > 0 {
+			<div class="board-collision">
+				for _, c := range col.Collisions {
+					<p>⚠ Spelleiar-kollisjon — { c.HostName } har { fmt.Sprintf("%d", c.Count) } spel i denne puljen</p>
+				}
+			</div>
+		}
+		<div class="board-col-body">
+			for _, g := range col.Games {
+				@gameCard(g, string(col.Pulje.ID), inCollision(col, g))
+			}
+		</div>
+	</div>
+}
+
+templ gameCard(g BoardGame, puljeID string, colliding bool) {
+	<div
+		class={ "board-card", templ.KV("is-colliding", colliding) }
+		draggable="true"
+		data-on:dragstart={ fmt.Sprintf("$draggedEventId = '%s'", g.EventID) }
+		data-on:dragend="$draggedEventId = ''; $dragOverPulje = ''"
+	>
+		<a class="board-card-title" href={ templ.SafeURL("/admin/approval/edit/" + g.EventID) }>{ g.Title }</a>
+		<span class="board-card-status">{ string(g.Status) }</span>
+		if puljeID != "" {
+			<button
+				type="button"
+				class="board-card-remove"
+				data-on:click={ fmt.Sprintf("@delete('/admin/api/puljeoppsett/%s/%s')", g.EventID, puljeID) }
+			>×</button>
+		}
+	</div>
+}
+
+func inCollision(col SlotColumn, g BoardGame) bool {
+	for _, c := range col.Collisions {
+		if c.HostName == g.HostName {
+			return true
+		}
+	}
+	return false
+}
+
+templ scheduleBoardStyles() {
+	<style>
+		.board-columns {
+			display: flex;
+			gap: var(--spacing-2x);
+			overflow-x: auto;
+			padding: var(--spacing-2x) 0;
+			align-items: flex-start;
+		}
+		.board-col {
+			flex: 0 0 16rem;
+			display: flex;
+			flex-direction: column;
+			gap: var(--spacing-1x);
+			padding: var(--spacing-2x);
+			border: 1px solid var(--bg-item-border);
+			border-radius: var(--border-radius-1x);
+			background-color: var(--bg-item);
+			transition: border-color 300ms ease-in-out;
+		}
+		.board-col.is-drag-over {
+			border-color: var(--color-primary);
+			background-color: var(--bg-item-hover);
+		}
+		.board-col--pool { background-color: var(--bg-surface); }
+		.board-col-body {
+			display: flex;
+			flex-direction: column;
+			gap: var(--spacing-1x);
+		}
+		.board-stats { font-size: var(--text-body-small); color: var(--color-disabled); }
+		.board-collision, .board-collision-summary {
+			color: var(--color-error);
+			font-weight: bold;
+			border: 2px solid var(--color-error);
+			border-radius: var(--border-radius-1x);
+			padding: var(--spacing-1x);
+		}
+		.board-card {
+			position: relative;
+			display: flex;
+			flex-direction: column;
+			gap: 2px;
+			padding: var(--spacing-1x);
+			border: 2px solid var(--bg-item-border);
+			border-radius: var(--border-radius-2x);
+			background-color: var(--bg-item);
+			cursor: grab;
+		}
+		.board-card.is-colliding { border-color: var(--color-error); }
+		.board-card-title { font-weight: bold; text-decoration: none; color: var(--color-primary-text); }
+		.board-card-status { font-size: var(--text-body-small); color: var(--color-disabled); }
+		.board-card-remove {
+			position: absolute;
+			top: 2px;
+			right: 2px;
+			background: none;
+			border: none;
+			color: var(--color-error);
+			cursor: pointer;
+			font-size: 1.1rem;
+			line-height: 1;
+		}
+	</style>
+}

--- a/pages/admin/puljeoppsett.templ
+++ b/pages/admin/puljeoppsett.templ
@@ -1,12 +1,19 @@
 package admin
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/components/formsubmission"
+	"github.com/Regncon/conorganizer/layouts"
+	"github.com/Regncon/conorganizer/models"
 	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/service/userctx"
+	"github.com/go-chi/chi/v5"
 )
 
 templ scheduleBoardIndex(db *sql.DB, logger *slog.Logger) {
@@ -116,6 +123,62 @@ func inCollision(col SlotColumn, g BoardGame) bool {
 		}
 	}
 	return false
+}
+
+// puljeoppsettRoute wires the game→slot board: a drag-and-drop view that toggles
+// relation_event_puljer.is_in_pulje. Membership changes broadcast on BucketEvents
+// so every connected admin's board live-updates.
+func puljeoppsettRoute(router chi.Router, db *sql.DB, liveManager *live.Manager, logger *slog.Logger) {
+	logger = logger.With("component", "admin_puljeoppsett")
+
+	router.Get("/puljeoppsett/", func(w http.ResponseWriter, r *http.Request) {
+		userInfo := userctx.GetUserRequestInfo(r.Context())
+		if err := layouts.Base("Puljeoppsett", userInfo, scheduleBoardIndex(db, logger)).
+			Render(r.Context(), w); err != nil {
+			logger.Error(fmt.Errorf("render puljeoppsett page: %w", err).Error())
+		}
+	})
+
+	router.Get("/api/puljeoppsett", func(w http.ResponseWriter, r *http.Request) {
+		liveManager.Stream(w, r, live.Page{
+			Buckets: []live.Bucket{live.BucketEvents},
+			Render: func(ctx context.Context, r *http.Request) templ.Component {
+				return ScheduleBoardContent(db, logger)
+			},
+		})
+	})
+
+	router.Put("/api/puljeoppsett/{event}/{pulje}/add", func(w http.ResponseWriter, r *http.Request) {
+		setMembership(w, r, db, liveManager, logger, true)
+	})
+
+	router.Delete("/api/puljeoppsett/{event}/{pulje}", func(w http.ResponseWriter, r *http.Request) {
+		setMembership(w, r, db, liveManager, logger, false)
+	})
+}
+
+func setMembership(w http.ResponseWriter, r *http.Request, db *sql.DB, liveManager *live.Manager, logger *slog.Logger, inPulje bool) {
+	eventID := chi.URLParam(r, "event")
+	if eventID == "" {
+		http.Error(w, "Arrangement-ID manglar", http.StatusBadRequest)
+		return
+	}
+	puljeID, ok := models.ParsePulje(chi.URLParam(r, "pulje"))
+	if !ok {
+		http.Error(w, "Ugyldig pulje-ID", http.StatusBadRequest)
+		return
+	}
+	if err := formsubmission.SetEventInPulje(r.Context(), db, logger, eventID, string(puljeID), inPulje); err != nil {
+		logger.Error(fmt.Errorf("set membership event %s pulje %s: %w", eventID, puljeID, err).Error())
+		http.Error(w, "Klarte ikkje å oppdatere puljen", http.StatusInternalServerError)
+		return
+	}
+	// Live broadcast is best-effort: the write is already committed, so a failed
+	// refresh must not fail the request. Log and return success.
+	if err := liveManager.Broadcast(r.Context(), live.BucketEvents); err != nil {
+		logger.Warn(fmt.Errorf("broadcast membership update for event %s pulje %s: %w", eventID, puljeID, err).Error())
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 templ scheduleBoardStyles() {

--- a/pages/admin/puljeoppsett_board.go
+++ b/pages/admin/puljeoppsett_board.go
@@ -1,0 +1,169 @@
+package admin
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/Regncon/conorganizer/models"
+	puljerService "github.com/Regncon/conorganizer/service/puljer"
+)
+
+// BoardGame is one game card on the puljeoppsett board.
+type BoardGame struct {
+	EventID  string
+	Title    string
+	Status   models.EventStatus
+	AgeGroup models.AgeGroup
+	Beginner bool
+	OwnerKey string // "user:<id>" or "email:<lowercased>" — DM identity
+	HostName string
+}
+
+// SlotStats are the per-column counters shown in the header.
+type SlotStats struct {
+	Games    int
+	Adults   int // age_group == AdultsOnly
+	Beginner int // beginner_friendly
+}
+
+// DMCollision is one owner who runs >=2 games in the same pulje.
+type DMCollision struct {
+	HostName string
+	Count    int
+}
+
+// SlotColumn is one pulje column: its games, stats and collisions.
+type SlotColumn struct {
+	Pulje      models.PuljeRow
+	Games      []BoardGame
+	Stats      SlotStats
+	Collisions []DMCollision
+}
+
+// ScheduleBoard is the whole board: pool + one column per pulje.
+type ScheduleBoard struct {
+	Pool           []BoardGame
+	Columns        []SlotColumn
+	CollisionCount int
+}
+
+func ownerKey(userID sql.NullInt64, email string) string {
+	if userID.Valid {
+		return fmt.Sprintf("user:%d", userID.Int64)
+	}
+	return "email:" + strings.ToLower(strings.TrimSpace(email))
+}
+
+// buildScheduleBoard loads eligible games (Godkjent/Annonsert), shapes them into
+// a pool (games in no pulje) plus one column per pulje (ordered by start_at), and
+// computes per-slot stats and DM double-booking collisions.
+func buildScheduleBoard(db *sql.DB, logger *slog.Logger) (ScheduleBoard, error) {
+	puljer, err := puljerService.GetAllPuljer(db)
+	if err != nil {
+		return ScheduleBoard{}, fmt.Errorf("load puljer: %w", err)
+	}
+
+	const query = `
+		SELECT e.id, e.title, e.status, e.age_group, e.beginner_friendly,
+		       e.user_id, e.email, e.host_name, ep.pulje_id
+		FROM events e
+		LEFT JOIN relation_event_puljer ep
+		       ON ep.event_id = e.id AND ep.is_in_pulje = 1
+		WHERE e.status IN ('Godkjent', 'Annonsert')
+		ORDER BY e.title ASC
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return ScheduleBoard{}, fmt.Errorf("query board games: %w", err)
+	}
+	defer rows.Close()
+
+	gamesByPulje := make(map[models.Pulje][]BoardGame)
+	poolByID := make(map[string]BoardGame)
+	slotted := make(map[string]bool)
+
+	for rows.Next() {
+		var (
+			g       BoardGame
+			userID  sql.NullInt64
+			email   string
+			puljeID sql.NullString
+			beginI  int
+		)
+		if err := rows.Scan(&g.EventID, &g.Title, &g.Status, &g.AgeGroup, &beginI,
+			&userID, &email, &g.HostName, &puljeID); err != nil {
+			return ScheduleBoard{}, fmt.Errorf("scan board game: %w", err)
+		}
+		g.Beginner = beginI == 1
+		g.OwnerKey = ownerKey(userID, email)
+
+		poolByID[g.EventID] = g
+		if puljeID.Valid {
+			p := models.Pulje(puljeID.String)
+			gamesByPulje[p] = append(gamesByPulje[p], g)
+			slotted[g.EventID] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return ScheduleBoard{}, fmt.Errorf("iterate board games: %w", err)
+	}
+
+	board := ScheduleBoard{}
+	for _, p := range puljer {
+		col := SlotColumn{Pulje: p, Games: gamesByPulje[p.ID]}
+		col.Stats = computeStats(col.Games)
+		col.Collisions = computeCollisions(col.Games)
+		board.CollisionCount += len(col.Collisions)
+		board.Columns = append(board.Columns, col)
+	}
+	board.Pool = poolGames(poolByID, slotted)
+
+	return board, nil
+}
+
+func computeStats(games []BoardGame) SlotStats {
+	s := SlotStats{Games: len(games)}
+	for _, g := range games {
+		if g.AgeGroup == models.AgeGroupAdultsOnly {
+			s.Adults++
+		}
+		if g.Beginner {
+			s.Beginner++
+		}
+	}
+	return s
+}
+
+func computeCollisions(games []BoardGame) []DMCollision {
+	order := []string{}
+	counts := map[string]int{}
+	host := map[string]string{}
+	for _, g := range games {
+		if _, seen := counts[g.OwnerKey]; !seen {
+			order = append(order, g.OwnerKey)
+			host[g.OwnerKey] = g.HostName
+		}
+		counts[g.OwnerKey]++
+	}
+	var out []DMCollision
+	for _, key := range order {
+		if counts[key] >= 2 {
+			out = append(out, DMCollision{HostName: host[key], Count: counts[key]})
+		}
+	}
+	return out
+}
+
+func poolGames(byID map[string]BoardGame, slotted map[string]bool) []BoardGame {
+	var out []BoardGame
+	for id, g := range byID {
+		if !slotted[id] {
+			out = append(out, g)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Title < out[j].Title })
+	return out
+}

--- a/pages/admin/puljeoppsett_board_test.go
+++ b/pages/admin/puljeoppsett_board_test.go
@@ -1,0 +1,118 @@
+package admin
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func insertBoardEvent(t *testing.T, db *sql.DB, id, title, status, ageGroup string, beginner, userID int, email, host string) {
+	t.Helper()
+	var userCol any
+	if userID > 0 {
+		userCol = userID
+	} else {
+		userCol = nil
+	}
+	_, err := db.Exec(
+		`INSERT INTO events (id, title, intro, description, status, age_group, beginner_friendly, user_id, host_name, email, phone_number, max_players)
+		 VALUES (?, ?, '', '', ?, ?, ?, ?, ?, ?, '', 4)`,
+		id, title, status, ageGroup, beginner, userCol, host, email)
+	if err != nil {
+		t.Fatalf("insert event %s: %v", id, err)
+	}
+}
+
+func placeBoardInPulje(t *testing.T, db *sql.DB, eventID string, pulje models.Pulje) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES (?, ?, 1)`,
+		eventID, string(pulje)); err != nil {
+		t.Fatalf("place %s in %s: %v", eventID, pulje, err)
+	}
+}
+
+func TestBuildScheduleBoard_PoolStatsAndCollisions(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "build_schedule_board")
+
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeFredagKveld), "Fredag Kveld", "Open", "2026-01-01 18:00", "2026-01-01 22:00")
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeLordagKveld), "Lørdag Kveld", "Open", "2026-01-02 18:00", "2026-01-02 22:00")
+
+	// Owner Ola (user 7) runs two adult games — both in Fredag => collision.
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email) VALUES (7, 'ext7', 'ola@x.no')`)
+	insertBoardEvent(t, db, "g1", "Drager", "Godkjent", "AdultsOnly", 0, 7, "ola@x.no", "Ola")
+	insertBoardEvent(t, db, "g2", "Demoner", "Annonsert", "AdultsOnly", 0, 7, "ola@x.no", "Ola")
+	placeBoardInPulje(t, db, "g1", models.PuljeFredagKveld)
+	placeBoardInPulje(t, db, "g2", models.PuljeFredagKveld)
+
+	// Beginner game by Kari, in Lørdag only.
+	insertBoardEvent(t, db, "g3", "Nybegynner", "Godkjent", "Default", 1, 0, "kari@x.no", "Kari")
+	placeBoardInPulje(t, db, "g3", models.PuljeLordagKveld)
+
+	// Approved game in no pulje => pool.
+	insertBoardEvent(t, db, "g4", "Ledig", "Godkjent", "Default", 0, 0, "per@x.no", "Per")
+
+	// Draft must never appear.
+	insertBoardEvent(t, db, "g5", "Kladd", "Kladd", "Default", 0, 0, "x@x.no", "X")
+
+	board, err := buildScheduleBoard(db, logger)
+	if err != nil {
+		t.Fatalf("buildScheduleBoard: %v", err)
+	}
+
+	if len(board.Pool) != 1 || board.Pool[0].EventID != "g4" {
+		t.Fatalf("pool = %+v, want only g4", board.Pool)
+	}
+
+	if len(board.Columns) != 2 ||
+		board.Columns[0].Pulje.ID != models.PuljeFredagKveld ||
+		board.Columns[1].Pulje.ID != models.PuljeLordagKveld {
+		t.Fatalf("columns order wrong: %+v", board.Columns)
+	}
+
+	fredag := board.Columns[0]
+	if fredag.Stats.Games != 2 || fredag.Stats.Adults != 2 || fredag.Stats.Beginner != 0 {
+		t.Fatalf("fredag stats = %+v, want {2 2 0}", fredag.Stats)
+	}
+	if len(fredag.Collisions) != 1 || fredag.Collisions[0].HostName != "Ola" || fredag.Collisions[0].Count != 2 {
+		t.Fatalf("fredag collisions = %+v, want one Ola x2", fredag.Collisions)
+	}
+
+	lordag := board.Columns[1]
+	if lordag.Stats.Games != 1 || lordag.Stats.Adults != 0 || lordag.Stats.Beginner != 1 {
+		t.Fatalf("lordag stats = %+v, want {1 0 1}", lordag.Stats)
+	}
+	if len(lordag.Collisions) != 0 {
+		t.Fatalf("lordag collisions = %+v, want none", lordag.Collisions)
+	}
+
+	if board.CollisionCount != 1 {
+		t.Fatalf("CollisionCount = %d, want 1", board.CollisionCount)
+	}
+}
+
+func TestBuildScheduleBoard_SameOwnerDifferentPuljerNoCollision(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "build_board_no_collision")
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeFredagKveld), "Fredag", "Open", "2026-01-01 18:00", "2026-01-01 22:00")
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeLordagKveld), "Lørdag", "Open", "2026-01-02 18:00", "2026-01-02 22:00")
+
+	// Same owner (null user_id, same email) but in different puljer => no collision.
+	insertBoardEvent(t, db, "a", "A", "Godkjent", "Default", 0, 0, "same@x.no", "Sam")
+	insertBoardEvent(t, db, "b", "B", "Godkjent", "Default", 0, 0, "same@x.no", "Sam")
+	placeBoardInPulje(t, db, "a", models.PuljeFredagKveld)
+	placeBoardInPulje(t, db, "b", models.PuljeLordagKveld)
+
+	board, err := buildScheduleBoard(db, logger)
+	if err != nil {
+		t.Fatalf("buildScheduleBoard: %v", err)
+	}
+	if board.CollisionCount != 0 {
+		t.Fatalf("CollisionCount = %d, want 0", board.CollisionCount)
+	}
+}

--- a/pages/admin/puljeoppsett_render_test.go
+++ b/pages/admin/puljeoppsett_render_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/testutil"
+	"github.com/Regncon/conorganizer/testutil/templtest"
+)
+
+func TestScheduleBoardContent_RendersColumnsStatsAndPool(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "schedule_board_render")
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeFredagKveld), "Fredag Kveld", "Open", "2026-01-01 18:00", "2026-01-01 22:00")
+	insertBoardEvent(t, db, "g1", "Drager", "Godkjent", "AdultsOnly", 0, 0, "ola@x.no", "Ola")
+	placeBoardInPulje(t, db, "g1", models.PuljeFredagKveld)
+	insertBoardEvent(t, db, "g4", "Ledig spel", "Godkjent", "Default", 0, 0, "per@x.no", "Per")
+
+	doc := templtest.Render(t, ScheduleBoardContent(db, logger))
+	text := strings.Join(templtest.CollectTexts(doc, "#puljeoppsett-board"), " ")
+
+	for _, want := range []string{"Fredag Kveld", "Drager", "Ledig spel", "ingen pulje", "1 spel", "18+"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("board text missing %q\ngot: %s", want, text)
+		}
+	}
+}
+
+func TestScheduleBoardContent_ShowsDMCollisionWarning(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "schedule_board_collision")
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeFredagKveld), "Fredag Kveld", "Open", "2026-01-01 18:00", "2026-01-01 22:00")
+	insertBoardEvent(t, db, "g1", "Drager", "Godkjent", "Default", 0, 0, "ola@x.no", "Ola")
+	insertBoardEvent(t, db, "g2", "Demoner", "Godkjent", "Default", 0, 0, "ola@x.no", "Ola")
+	placeBoardInPulje(t, db, "g1", models.PuljeFredagKveld)
+	placeBoardInPulje(t, db, "g2", models.PuljeFredagKveld)
+
+	doc := templtest.Render(t, ScheduleBoardContent(db, logger))
+	text := strings.Join(templtest.CollectTexts(doc, "#puljeoppsett-board"), " ")
+
+	for _, want := range []string{"Spelleiar-kollisjon", "Ola"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("collision warning missing %q\ngot: %s", want, text)
+		}
+	}
+}

--- a/pages/admin/puljeoppsett_route_test.go
+++ b/pages/admin/puljeoppsett_route_test.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/service/authctx"
+	"github.com/Regncon/conorganizer/service/live"
+	"github.com/Regncon/conorganizer/testutil"
+	"github.com/go-chi/chi/v5"
+)
+
+func authedRequest(method, target string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	return req.WithContext(authctx.WithUserToken(req.Context(), "ext-42", "admin@x.no"))
+}
+
+func TestPuljeoppsettRoute_AddAndRemoveMembership(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljeoppsett_route")
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email, is_admin) VALUES (42, 'ext-42', 'admin@x.no', 1)`)
+	testutil.MustExec(t, db, `INSERT INTO puljer (id, name, status, start_at, end_at) VALUES (?,?,?,?,?)`,
+		string(models.PuljeFredagKveld), "Fredag", "Open", "2026-01-01 18:00", "2026-01-01 22:00")
+	insertBoardEvent(t, db, "e1", "Spel", "Godkjent", "Default", 0, 0, "ola@x.no", "Ola")
+
+	router := chi.NewRouter()
+	puljeoppsettRoute(router, db, &live.Manager{}, logger)
+
+	addRec := httptest.NewRecorder()
+	router.ServeHTTP(addRec, authedRequest(http.MethodPut,
+		"/api/puljeoppsett/e1/"+string(models.PuljeFredagKveld)+"/add"))
+	if addRec.Code != http.StatusNoContent {
+		t.Fatalf("add status = %d, want 204\nbody: %s", addRec.Code, addRec.Body.String())
+	}
+	if got := testutil.QueryInt(t, db,
+		`SELECT is_in_pulje FROM relation_event_puljer WHERE event_id='e1' AND pulje_id=?`,
+		string(models.PuljeFredagKveld)); got != 1 {
+		t.Fatalf("after add is_in_pulje = %d, want 1", got)
+	}
+
+	delRec := httptest.NewRecorder()
+	router.ServeHTTP(delRec, authedRequest(http.MethodDelete,
+		"/api/puljeoppsett/e1/"+string(models.PuljeFredagKveld)))
+	if delRec.Code != http.StatusNoContent {
+		t.Fatalf("remove status = %d, want 204\nbody: %s", delRec.Code, delRec.Body.String())
+	}
+	if got := testutil.QueryInt(t, db,
+		`SELECT is_in_pulje FROM relation_event_puljer WHERE event_id='e1' AND pulje_id=?`,
+		string(models.PuljeFredagKveld)); got != 0 {
+		t.Fatalf("after remove is_in_pulje = %d, want 0", got)
+	}
+}
+
+func TestPuljeoppsettRoute_RejectsBadPulje(t *testing.T) {
+	db, logger := testutil.CreateTestDBAndLogger(t, "puljeoppsett_route_bad")
+	router := chi.NewRouter()
+	puljeoppsettRoute(router, db, &live.Manager{}, logger)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, authedRequest(http.MethodPut, "/api/puljeoppsett/e1/NotAPulje/add"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad pulje status = %d, want 400", rec.Code)
+	}
+}

--- a/service/authctx/test_support.go
+++ b/service/authctx/test_support.go
@@ -1,0 +1,19 @@
+package authctx
+
+import (
+	"context"
+
+	"github.com/descope/go-sdk/descope"
+)
+
+// WithUserToken returns ctx carrying a user token for the given external ID and
+// email. It is intended for tests that exercise authenticated handlers or
+// services (for example audited writes that resolve the current user from the
+// request context). The token context key is unexported, so this helper is the
+// only way to inject a user from outside this package.
+func WithUserToken(ctx context.Context, externalID, email string) context.Context {
+	return context.WithValue(ctx, ctxUserToken, &descope.Token{
+		ID:     externalID,
+		Claims: map[string]any{"email": email},
+	})
+}


### PR DESCRIPTION
## What

A new admin board at **`/admin/puljeoppsett/`** for assigning games (events) to time slots (puljer) by drag-and-drop. Scope is strictly game↔slot membership (`relation_event_puljer.is_in_pulje`); rooms, publishing, and player/GM seating keep their existing views.

## How it works

- **Layout:** a pool column ("I ingen pulje") plus one column per pulje, ordered by `start_at`.
- **Add-on-drop, × to remove:** dropping a game onto a slot adds it there (never removes it from another slot); a × on each slot card removes it from that one slot. A game in zero slots sits in the pool. Multi-slot games are native — drop the same game into several slots.
- **Eligible games:** only `Godkjent`/`Annonsert`.
- **Per-slot stat chips:** games · 18+ (`AdultsOnly`) · nybegynnarvennleg (`beginner_friendly`).
- **DM double-booking warning (large, warn-not-block):** if one game owner has ≥2 games in the same slot, a board-level summary, a red column banner, and red borders on the colliding cards appear. DM identity = game owner (`user_id`, falling back to host email).
- Pure Datastar drag-drop (no custom JS), reusing the restored #453 pattern; live updates over `BucketEvents`.

## Implementation notes

- Extracted the existing audited membership write into `formsubmission.SetEventInPulje`, now shared by the per-event form and this board (audit/`updated_by` preserved).
- Added `authctx.WithUserToken` test helper so cross-package tests can exercise audited writes that resolve the current user from context.
- Membership endpoints treat a failed live broadcast as best-effort (the DB write is already committed) — they log and still return 204, rather than 500-ing a successful write.

## Tests

- Data layer: pool/columns, stat counts, DM collision detection, "same owner across different slots = no collision".
- Render: columns/cards/stats/pool; collision banner.
- Routes: add/remove membership (204 + DB state), bad pulje → 400.
- Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)