### PR TITLE
feat: admin read-only "view as player" emulation

### DIFF
--- a/layouts/base.templ
+++ b/layouts/base.templ
@@ -2,6 +2,7 @@ package layouts
 
 import (
 	"github.com/Regncon/conorganizer/components/header"
+	"github.com/Regncon/conorganizer/service/emulatectx"
 	"github.com/Regncon/conorganizer/service/requestctx"
 )
 
@@ -40,10 +41,25 @@ templ Base(title string, userInfo requestctx.UserRequestInfo, children templ.Com
 			</script>
 		</head>
 		<body>
+			@emulationBanner(userInfo)
 			<main>
 				@header.Menu(userInfo)
 				@children
 			</main>
 		</body>
 	</html>
+}
+
+// emulationBanner is a sticky read-only notice shown only when an admin is
+// emulating a player. Its "Avslutt" link points at an /admin route, which the
+// emulate middleware treats as an auto-exit back to the admin's own view.
+templ emulationBanner(userInfo requestctx.UserRequestInfo) {
+	if emulatectx.IsEmulating(ctx) {
+		<div
+			style="position:sticky; top:0; z-index:1000; display:flex; align-items:center; justify-content:center; gap:1rem; padding:0.5rem 1rem; background:var(--color-primary-strong, #b8860b); color:#fff; font-weight:600;"
+		>
+			<span>👁 Du ser siden som spiller: { userInfo.Email } (skrivebeskyttet)</span>
+			<a href="/admin" class="btn btn--ghost" style="color:#fff; text-decoration:underline;">Avslutt</a>
+		</div>
+	}
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Regncon/conorganizer/service"
 	"github.com/Regncon/conorganizer/service/applog"
 	"github.com/Regncon/conorganizer/service/authctx"
+	"github.com/Regncon/conorganizer/service/emulatectx"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/joho/godotenv"
@@ -108,7 +109,10 @@ func startServer(ctx context.Context, logger *slog.Logger, port string, eventIma
 
 		var appRouter chi.Router = router
 		if fullMode {
-			appRouter = router.With(authctx.AuthMiddleware(baseLogger))
+			appRouter = router.With(
+				authctx.AuthMiddleware(baseLogger),
+				emulatectx.EmulateMiddleware(db, baseLogger),
+			)
 		}
 
 		if fullMode {

--- a/pages/admin/billettholder_admin/billettholder_admin.go
+++ b/pages/admin/billettholder_admin/billettholder_admin.go
@@ -19,6 +19,8 @@ func SetupBillettholderAdminRoute(router chi.Router, liveManager *live.Manager, 
 
 	indexRoute(router, db, logger)
 
+	EmulatePlayerRoute(router, db, logger)
+
 	router.Route("/admin/billettholder/api/", func(billettholderAdminRouter chi.Router) {
 		billettholderAdminRouter.With(authctx.RequireAdmin(baseLogger)).Get("/", func(w http.ResponseWriter, r *http.Request) {
 			liveManager.Stream(w, r, live.Page{

--- a/pages/admin/billettholder_admin/billettholder_card.templ
+++ b/pages/admin/billettholder_admin/billettholder_card.templ
@@ -336,5 +336,10 @@ templ billettholderCard(billettholder models.Billettholder, searchTerm string, i
 		>
 			Legg til epost
 		</button>
+		<form method="post" action={ templ.SafeURL(fmt.Sprintf("/admin/emulate/%d/", billettholder.ID)) } style="margin:0;">
+			<button class="btn btn--ghost" type="submit" title="Se nettsiden slik denne spilleren ser den (skrivebeskyttet)">
+				👁 Se som spiller
+			</button>
+		</form>
 	</div>
 }

--- a/pages/admin/billettholder_admin/emulate_route.go
+++ b/pages/admin/billettholder_admin/emulate_route.go
@@ -1,0 +1,69 @@
+package billettholderadmin
+
+import (
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Regncon/conorganizer/service/emulatectx"
+)
+
+// EmulatePlayerRoute mounts POST /admin/emulate/{billettholderID}/, which starts
+// read-only "view as player" emulation for the user account linked to the given
+// billettholder. The route is admin-only (the router is expected to carry
+// RequireAdmin). On success it sets the emulate_target cookie to the linked
+// user's id and redirects to the player home page.
+func EmulatePlayerRoute(router chi.Router, db *sql.DB, logger *slog.Logger) {
+	logger = logger.With("component", "billettholder_admin")
+	router.Post("/admin/emulate/{billettholderID}/", func(w http.ResponseWriter, r *http.Request) {
+		billettholderID := chi.URLParam(r, "billettholderID")
+		if _, err := strconv.Atoi(billettholderID); err != nil {
+			http.Error(w, "Ugyldig billettholder-id", http.StatusBadRequest)
+			return
+		}
+
+		userID, err := linkedNonAdminUserID(db, billettholderID)
+		if err == sql.ErrNoRows {
+			http.Error(w, "Denne billettholderen har ingen brukerkonto å se som.", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			logger.Error("failed to resolve linked user for emulation", "billettholder_id", billettholderID, "error", err)
+			http.Error(w, "Noe gikk galt, prøv igjen", http.StatusInternalServerError)
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{
+			Name:     emulatectx.CookieName,
+			Value:    strconv.Itoa(userID),
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   r.TLS != nil,
+			SameSite: http.SameSiteLaxMode,
+		})
+		logger.Info("started player emulation", "billettholder_id", billettholderID, "user_id", userID)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	})
+}
+
+// linkedNonAdminUserID returns the id of the non-admin user account linked to the
+// billettholder. Emulation targets a non-admin player; if several are linked the
+// lowest user id wins. Returns sql.ErrNoRows when no non-admin account is linked.
+func linkedNonAdminUserID(db *sql.DB, billettholderID string) (int, error) {
+	const query = `
+		SELECT u.id
+		FROM relation_billettholdere_users r
+		JOIN users u ON u.id = r.user_id
+		WHERE r.billettholder_id = ? AND u.is_admin = 0
+		ORDER BY u.id ASC
+		LIMIT 1
+	`
+	var userID int
+	if err := db.QueryRow(query, billettholderID).Scan(&userID); err != nil {
+		return 0, err
+	}
+	return userID, nil
+}

--- a/pages/admin/billettholder_admin/emulate_route_test.go
+++ b/pages/admin/billettholder_admin/emulate_route_test.go
@@ -1,0 +1,72 @@
+package billettholderadmin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Regncon/conorganizer/service/emulatectx"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+func setupEmulateRouteTest(t testing.TB) (chi.Router, *testutil.StubLogger) {
+	t.Helper()
+
+	db, logger := testutil.CreateTestDBAndLogger(t, "admin_emulate_route")
+	insertAdminRouteTestBillettholder(t, db, 7)
+	insertAdminRouteTestUser(t, db, 42, "player@example.com")
+	insertAdminRouteTestBillettholderUserAssociation(t, db, 7, 42)
+
+	// A billettholder with no linked user account.
+	insertAdminRouteTestBillettholder(t, db, 8)
+
+	router := chi.NewRouter()
+	EmulatePlayerRoute(router, db, logger)
+	return router, nil
+}
+
+func TestEmulatePlayerRoute_WithLinkedUser_SetsCookieAndRedirects(t *testing.T) {
+	router, _ := setupEmulateRouteTest(t)
+
+	request := httptest.NewRequest(http.MethodPost, "/admin/emulate/7/", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusSeeOther {
+		t.Fatalf("status mismatch\nexpected: %d\nactual:   %d", http.StatusSeeOther, recorder.Code)
+	}
+	if location := recorder.Header().Get("Location"); location != "/" {
+		t.Fatalf("redirect mismatch\nexpected: %q\nactual:   %q", "/", location)
+	}
+	var found *http.Cookie
+	for _, c := range recorder.Result().Cookies() {
+		if c.Name == emulatectx.CookieName {
+			found = c
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected %s cookie to be set", emulatectx.CookieName)
+	}
+	if found.Value != "42" {
+		t.Fatalf("cookie value mismatch\nexpected: %q\nactual:   %q", "42", found.Value)
+	}
+}
+
+func TestEmulatePlayerRoute_NoLinkedUser_ReturnsFriendlyErrorWithoutCookie(t *testing.T) {
+	router, _ := setupEmulateRouteTest(t)
+
+	request := httptest.NewRequest(http.MethodPost, "/admin/emulate/8/", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusSeeOther {
+		t.Fatalf("must not redirect when billettholder has no account")
+	}
+	for _, c := range recorder.Result().Cookies() {
+		if c.Name == emulatectx.CookieName && c.Value != "" {
+			t.Fatalf("must not set emulate cookie when no linked user")
+		}
+	}
+}

--- a/service/authctx/utils.go
+++ b/service/authctx/utils.go
@@ -10,6 +10,15 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+// WithUserToken returns a context carrying token as the active user identity and
+// clears any prior session error, so downstream authctx getters read token. It is
+// the supported way for other packages (e.g. emulatectx) to replace the request
+// identity after AuthMiddleware has run.
+func WithUserToken(ctx context.Context, token *descope.Token) context.Context {
+	ctx = context.WithValue(ctx, ctxSessionError, nil)
+	return context.WithValue(ctx, ctxUserToken, token)
+}
+
 func GetUserTokenFromContext(ctx context.Context) (*descope.Token, error) {
 	if errVal := ctx.Value(ctxSessionError); errVal != nil {
 		return nil, fmt.Errorf("authentication error: %v", errVal)

--- a/service/authctx/with_user_token_test.go
+++ b/service/authctx/with_user_token_test.go
@@ -1,0 +1,37 @@
+package authctx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/descope/go-sdk/descope"
+)
+
+func TestWithUserToken_StoresTokenRetrievableFromContext(t *testing.T) {
+	token := &descope.Token{ID: "external-123", Claims: map[string]any{"email": "player@example.com"}}
+
+	ctx := WithUserToken(context.Background(), token)
+
+	got, err := GetUserTokenFromContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != token {
+		t.Fatalf("token mismatch\nexpected: %v\nactual:   %v", token, got)
+	}
+}
+
+func TestWithUserToken_ClearsPriorSessionError(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxSessionError, context.DeadlineExceeded)
+	token := &descope.Token{ID: "external-123"}
+
+	ctx = WithUserToken(ctx, token)
+
+	got, err := GetUserTokenFromContext(ctx)
+	if err != nil {
+		t.Fatalf("expected session error to be cleared, got: %v", err)
+	}
+	if got != token {
+		t.Fatalf("token mismatch\nexpected: %v\nactual:   %v", token, got)
+	}
+}

--- a/service/emulatectx/emulatectx.go
+++ b/service/emulatectx/emulatectx.go
@@ -1,0 +1,139 @@
+// Package emulatectx lets an admin browse the site read-only as a specific
+// non-admin player ("view as"). A middleware runs after authctx.AuthMiddleware:
+// when the real user is an admin and an emulate_target cookie is present, it
+// replaces the request identity with a synthesized token for the target player
+// (no Admin role) and stashes the real admin token so the banner and exit flow
+// keep working. Navigating to any /admin route auto-exits emulation.
+package emulatectx
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/descope/go-sdk/descope"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/Regncon/conorganizer/service/authctx"
+)
+
+// CookieName is the cookie holding the emulated target's users.id.
+const CookieName = "emulate_target"
+
+type realAdminTokenKey struct{}
+
+// EmulateMiddleware swaps the request identity to the cookie's target player when
+// the real user is an admin. It must be mounted after authctx.AuthMiddleware.
+func EmulateMiddleware(db *sql.DB, logger *slog.Logger) func(http.Handler) http.Handler {
+	logger = logger.With("component", "emulate")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestID := middleware.GetReqID(r.Context())
+
+			cookie, cookieErr := r.Cookie(CookieName)
+			if cookieErr != nil || cookie.Value == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Security gate: only a real admin can ever emulate. A non-admin
+			// presenting the cookie is ignored and the cookie cleared.
+			if !authctx.GetAdminFromUserToken(r.Context()) {
+				clearCookie(w, r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Auto-exit: any /admin navigation ends emulation and restores the
+			// admin's own view.
+			if isAdminPath(r.URL.Path) {
+				clearCookie(w, r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Read-only: block writes while emulating.
+			if !isSafeMethod(r.Method) {
+				http.Error(w, "Du ser siden som en spiller (skrivebeskyttet). Avslutt emuleringen for å gjøre endringer.", http.StatusForbidden)
+				return
+			}
+
+			external, email, loadErr := loadTargetUser(db, cookie.Value)
+			if loadErr != nil {
+				logger.Warn(fmt.Errorf("emulation target lookup failed: %w", loadErr).Error(), "request_id", requestID, "target", cookie.Value)
+				clearCookie(w, r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			realToken, _ := authctx.GetUserTokenFromContext(r.Context())
+			ctx := context.WithValue(r.Context(), realAdminTokenKey{}, realToken)
+			ctx = authctx.WithUserToken(ctx, syntheticToken(external, email))
+			logger.Debug("emulating player", "request_id", requestID, "target", cookie.Value)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// RealAdminTokenFromContext returns the stashed real admin token when the request
+// is an admin emulating a player.
+func RealAdminTokenFromContext(ctx context.Context) (*descope.Token, bool) {
+	token, ok := ctx.Value(realAdminTokenKey{}).(*descope.Token)
+	if !ok || token == nil {
+		return nil, false
+	}
+	return token, true
+}
+
+// IsEmulating reports whether the current request is an admin emulating a player.
+func IsEmulating(ctx context.Context) bool {
+	_, ok := RealAdminTokenFromContext(ctx)
+	return ok
+}
+
+func syntheticToken(externalID, email string) *descope.Token {
+	return &descope.Token{
+		ID: externalID,
+		Claims: map[string]any{
+			"email": email,
+			"roles": []any{},
+		},
+	}
+}
+
+func loadTargetUser(db *sql.DB, userID string) (externalID, email string, err error) {
+	const query = `SELECT external_id, email FROM users WHERE id = ?`
+	row := db.QueryRow(query, userID)
+	if scanErr := row.Scan(&externalID, &email); scanErr != nil {
+		return "", "", fmt.Errorf("load target user %q: %w", userID, scanErr)
+	}
+	return externalID, email, nil
+}
+
+func isAdminPath(path string) bool {
+	return path == "/admin" || strings.HasPrefix(path, "/admin/")
+}
+
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+func clearCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/service/emulatectx/emulatectx_test.go
+++ b/service/emulatectx/emulatectx_test.go
@@ -1,0 +1,216 @@
+package emulatectx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/descope/go-sdk/descope"
+
+	"github.com/Regncon/conorganizer/service/authctx"
+	"github.com/Regncon/conorganizer/service/emulatectx"
+	"github.com/Regncon/conorganizer/service/userctx"
+	"github.com/Regncon/conorganizer/testutil"
+)
+
+const (
+	targetUserID     = 42
+	targetExternalID = "player-external-42"
+	targetEmail      = "player@example.com"
+	adminExternalID  = "admin-external-1"
+	adminEmail       = "admin@example.com"
+	playerFacingPath = "/"
+	adminFacingPath  = "/admin/dashboard"
+)
+
+func adminToken() *descope.Token {
+	return &descope.Token{
+		ID:     adminExternalID,
+		Claims: map[string]any{"roles": []any{"Admin"}, "email": adminEmail},
+	}
+}
+
+func nonAdminToken() *descope.Token {
+	return &descope.Token{
+		ID:     "some-user",
+		Claims: map[string]any{"roles": []any{"User"}, "email": "user@example.com"},
+	}
+}
+
+func TestEmulateMiddleware_AdminWithCookie_SwapsIdentityToPlayer(t *testing.T) {
+	db := testutil.CreateTestDB(t, "emulatectx_swap")
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email, is_admin) VALUES (?, ?, ?, 0)`, targetUserID, targetExternalID, targetEmail)
+
+	var info struct {
+		id          string
+		email       string
+		isAdmin     bool
+		emulating   bool
+		hasReal     bool
+		realIsAdmin bool
+	}
+	handler := emulatectx.EmulateMiddleware(db, testutil.NewTestLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userInfo := userctx.GetUserRequestInfo(ctx)
+		info.id = userInfo.Id
+		info.email = userInfo.Email
+		info.isAdmin = userInfo.IsAdmin
+		info.emulating = emulatectx.IsEmulating(ctx)
+		real, ok := emulatectx.RealAdminTokenFromContext(ctx)
+		info.hasReal = ok
+		if ok {
+			info.realIsAdmin = authctx.GetAdminFromUserToken(authctx.WithUserToken(ctx, real))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, playerFacingPath, nil)
+	request = request.WithContext(authctx.WithUserToken(request.Context(), adminToken()))
+	request.AddCookie(&http.Cookie{Name: emulatectx.CookieName, Value: strconv.Itoa(targetUserID)})
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status mismatch\nexpected: %d\nactual:   %d", http.StatusOK, recorder.Code)
+	}
+	if info.id != targetExternalID {
+		t.Fatalf("emulated id mismatch\nexpected: %q\nactual:   %q", targetExternalID, info.id)
+	}
+	if info.email != targetEmail {
+		t.Fatalf("emulated email mismatch\nexpected: %q\nactual:   %q", targetEmail, info.email)
+	}
+	if info.isAdmin {
+		t.Fatalf("emulated player must not be admin")
+	}
+	if !info.emulating {
+		t.Fatalf("expected IsEmulating to be true")
+	}
+	if !info.hasReal || !info.realIsAdmin {
+		t.Fatalf("expected real admin token to be stashed and still admin")
+	}
+}
+
+func TestEmulateMiddleware_NonAdminWithCookie_IsIgnoredAndCleared(t *testing.T) {
+	db := testutil.CreateTestDB(t, "emulatectx_nonadmin")
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email, is_admin) VALUES (?, ?, ?, 0)`, targetUserID, targetExternalID, targetEmail)
+
+	var sawEmulation bool
+	var sawID string
+	handler := emulatectx.EmulateMiddleware(db, testutil.NewTestLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawEmulation = emulatectx.IsEmulating(r.Context())
+		sawID = userctx.GetUserRequestInfo(r.Context()).Id
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, playerFacingPath, nil)
+	request = request.WithContext(authctx.WithUserToken(request.Context(), nonAdminToken()))
+	request.AddCookie(&http.Cookie{Name: emulatectx.CookieName, Value: strconv.Itoa(targetUserID)})
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	if sawEmulation {
+		t.Fatalf("non-admin must never emulate")
+	}
+	if sawID != "some-user" {
+		t.Fatalf("non-admin identity must be unchanged\nexpected: %q\nactual:   %q", "some-user", sawID)
+	}
+	if !cookieCleared(recorder) {
+		t.Fatalf("expected emulate cookie to be cleared for non-admin")
+	}
+}
+
+func TestEmulateMiddleware_AdminPathWhileEmulating_AutoExits(t *testing.T) {
+	db := testutil.CreateTestDB(t, "emulatectx_autoexit")
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email, is_admin) VALUES (?, ?, ?, 0)`, targetUserID, targetExternalID, targetEmail)
+
+	var emulating bool
+	var isAdmin bool
+	handler := emulatectx.EmulateMiddleware(db, testutil.NewTestLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		emulating = emulatectx.IsEmulating(r.Context())
+		isAdmin = userctx.GetUserRequestInfo(r.Context()).IsAdmin
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, adminFacingPath, nil)
+	request = request.WithContext(authctx.WithUserToken(request.Context(), adminToken()))
+	request.AddCookie(&http.Cookie{Name: emulatectx.CookieName, Value: strconv.Itoa(targetUserID)})
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	if emulating {
+		t.Fatalf("admin route must auto-exit emulation")
+	}
+	if !isAdmin {
+		t.Fatalf("admin identity must be restored on admin route")
+	}
+	if !cookieCleared(recorder) {
+		t.Fatalf("expected emulate cookie to be cleared on auto-exit")
+	}
+}
+
+func TestEmulateMiddleware_UnsafeMethodWhileEmulating_IsBlocked(t *testing.T) {
+	db := testutil.CreateTestDB(t, "emulatectx_readonly")
+	testutil.MustExec(t, db, `INSERT INTO users (id, external_id, email, is_admin) VALUES (?, ?, ?, 0)`, targetUserID, targetExternalID, targetEmail)
+
+	handlerCalled := false
+	handler := emulatectx.EmulateMiddleware(db, testutil.NewTestLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, playerFacingPath, nil)
+	request = request.WithContext(authctx.WithUserToken(request.Context(), adminToken()))
+	request.AddCookie(&http.Cookie{Name: emulatectx.CookieName, Value: strconv.Itoa(targetUserID)})
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	if handlerCalled {
+		t.Fatalf("write must not reach handler while emulating")
+	}
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status mismatch\nexpected: %d\nactual:   %d", http.StatusForbidden, recorder.Code)
+	}
+}
+
+func TestEmulateMiddleware_MissingTargetUser_FallsBackToAdmin(t *testing.T) {
+	db := testutil.CreateTestDB(t, "emulatectx_missing")
+
+	var emulating bool
+	var isAdmin bool
+	handler := emulatectx.EmulateMiddleware(db, testutil.NewTestLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		emulating = emulatectx.IsEmulating(r.Context())
+		isAdmin = userctx.GetUserRequestInfo(r.Context()).IsAdmin
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, playerFacingPath, nil)
+	request = request.WithContext(authctx.WithUserToken(request.Context(), adminToken()))
+	request.AddCookie(&http.Cookie{Name: emulatectx.CookieName, Value: "9999"})
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	if emulating {
+		t.Fatalf("missing target must not emulate")
+	}
+	if !isAdmin {
+		t.Fatalf("admin identity must remain when target is missing")
+	}
+	if !cookieCleared(recorder) {
+		t.Fatalf("expected emulate cookie to be cleared when target missing")
+	}
+}
+
+func cookieCleared(recorder *httptest.ResponseRecorder) bool {
+	for _, c := range recorder.Result().Cookies() {
+		if c.Name == emulatectx.CookieName && c.MaxAge < 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Lets an admin browse the site **exactly as a specific non-admin player sees it** — for support, UX preview, and permission checks. The emulation is **read-only**.

Started from a **"👁 Se som spiller"** button on each billettholder card; persists across navigation via a cookie; a sticky banner shows who you're viewing as. Navigating to any `/admin` route **auto-exits** back to your own admin view.

## How it works

- **`service/emulatectx`** — a new middleware mounted right after `AuthMiddleware`. When an `emulate_target` cookie is present **and the real user is Admin**, it loads the target user and replaces the request identity with a synthesized non-admin token. Every existing `authctx`/`userctx` getter then transparently returns the emulated player — no changes to pages or getters.
  - **Security gate:** a non-admin presenting the cookie is ignored and the cookie cleared. Emulation can only ever *drop* privileges.
  - **Auto-exit:** any `/admin/*` request ends emulation and restores the admin.
  - **Read-only:** unsafe HTTP methods (POST/PUT/PATCH/DELETE) are blocked while emulating.
  - Missing/stale target → falls back to admin, cookie cleared.
- **`authctx.WithUserToken`** — new exported setter so `emulatectx` can replace the identity (single chokepoint; dogfooded by the middleware).
- **`POST /admin/emulate/{billettholderID}`** (admin-gated) — resolves the billettholder's linked non-admin user via `relation_billettholdere_users`, sets the cookie, redirects to `/`. Friendly error when no account is linked.
- **Banner** in `layouts.Base` — sticky read-only notice shown only while emulating, with an **Avslutt** link to `/admin` (auto-exits).

## Design doc

`docs/superpowers/specs/2026-06-26-emulate-player-design.md` (local/untracked per repo convention).

## Tests

TDD throughout — new tests cover identity swap, the non-admin security gate, auto-exit on `/admin`, the read-only write-guard, missing target, `WithUserToken`, and the start route (linked user → cookie+redirect; no account → friendly error).

- `go test ./...` → **31 packages pass, 0 failures**
- `go build ./...` clean · `golangci-lint` 0 issues

## Notes for reviewers

- While emulating, player-facing Datastar **POSTs are intentionally blocked** by the read-only guard (surfaces a 403). This matches the read-only design choice.
- A pre-existing **orphaned generated file** (`pages/admin/puljeoppsett_templ.go`, gitignored, no `.templ` source) was breaking the build locally; regenerating templ cleared it. No tracked files for that — just flagging in case others hit it.

<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://472-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->