### PR TITLE
Puljefordeling: interest-picker icons, event tags, faded game art

### DIFF
--- a/components/ticket_holder/ticket_holder_interest_picker.templ
+++ b/components/ticket_holder/ticket_holder_interest_picker.templ
@@ -113,7 +113,7 @@ templ TicketHolderInterestPicker(
 			data-attr:tabindex={ fmt.Sprintf("!$puljeCanEdit ? '-1' : $currentInterestLevelChoice === '%s' ? $selectedInterestLevel === '%s' ? '-1' : '0' : '0'", pendingChoice, models.InterestLevelHigh) }
 			data-on:click={ fmt.Sprintf("if ($puljeCanEdit) { $currentInterestLevelChoice = '%s'; @put('/event/api/%s/interest/update/interest') }", models.InterestLevelHigh, eventId) }
 		>
-			<span class="emoji">🤩</span> { models.InterestLevelHigh.Label() }
+			<span class="emoji">{ models.InterestLevelHigh.Emoji() }</span> { models.InterestLevelHigh.Label() }
 		</div>
 		<div
 			role="button"
@@ -123,7 +123,7 @@ templ TicketHolderInterestPicker(
 			data-attr:tabindex={ fmt.Sprintf("!$puljeCanEdit ? '-1' : $currentInterestLevelChoice === '%s' ? $selectedInterestLevel === '%s' ? '-1' : '0' : '0'", pendingChoice, models.InterestLevelMedium) }
 			data-on:click={ fmt.Sprintf("if ($puljeCanEdit) { $currentInterestLevelChoice = '%s'; @put('/event/api/%s/interest/update/interest') }", models.InterestLevelMedium, eventId) }
 		>
-			<span class="emoji">🙂</span> { models.InterestLevelMedium.Label() }
+			<span class="emoji">{ models.InterestLevelMedium.Emoji() }</span> { models.InterestLevelMedium.Label() }
 		</div>
 		<div
 			role="button"
@@ -133,7 +133,7 @@ templ TicketHolderInterestPicker(
 			data-attr:tabindex={ fmt.Sprintf("!$puljeCanEdit ? '-1' : $currentInterestLevelChoice === '%s' ? $selectedInterestLevel === '%s' ? '-1' : '0' : '0'", pendingChoice, models.InterestLevelLow) }
 			data-on:click={ fmt.Sprintf("if ($puljeCanEdit) { $currentInterestLevelChoice = '%s'; @put('/event/api/%s/interest/update/interest') }", models.InterestLevelLow, eventId) }
 		>
-			<span class="emoji">🤨</span> { models.InterestLevelLow.Label() }
+			<span class="emoji">{ models.InterestLevelLow.Emoji() }</span> { models.InterestLevelLow.Label() }
 		</div>
 		<div
 			role="button"

--- a/models/interests-model.go
+++ b/models/interests-model.go
@@ -66,15 +66,20 @@ func InterestLevelFromScore(score int) InterestLevel {
 }
 
 // Emoji returns a short glyph for an interest level, used to show at a glance
-// how much a seated participant wanted the game they got.
+// how much a seated participant wanted the game they got. These are the single
+// source of truth for the interest glyphs and match the buttons in the interest
+// picker (TicketHolderInterestPicker), so the two views never drift apart.
+// InterestLevelNone deliberately returns "" — the puljefordeling box uses the
+// empty string as the signal to substitute a 📌 pin for a manual seat that has
+// no real interest behind it.
 func (level InterestLevel) Emoji() string {
 	switch level {
 	case InterestLevelHigh:
-		return "🔥"
+		return "🤩"
 	case InterestLevelMedium:
-		return "👍"
+		return "🙂"
 	case InterestLevelLow:
-		return "🤷"
+		return "🤨"
 	default:
 		return ""
 	}

--- a/pages/admin/admin.go
+++ b/pages/admin/admin.go
@@ -28,7 +28,7 @@ func SetupAdminRoute(router chi.Router, logger *slog.Logger, liveManager *live.M
 	router.Route("/admin", func(adminRouter chi.Router) {
 		adminLayoutRoute(adminRouter, db, logger)
 		puljefordelingStatusRoute(adminRouter, db, liveManager, logger)
-		puljefordelingRoute(adminRouter, db, liveManager, baseLogger)
+		puljefordelingRoute(adminRouter, db, liveManager, baseLogger, eventImageDir)
 		programPublishingRoute(adminRouter, db, liveManager, logger)
 		adminRouter.Get("/api/", func(w http.ResponseWriter, r *http.Request) {
 			liveManager.Stream(w, r, live.Page{

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -10,9 +10,12 @@ import (
 	"strings"
 
 	"github.com/Regncon/conorganizer/components"
+	"github.com/Regncon/conorganizer/components/event_components"
 	"github.com/Regncon/conorganizer/components/formsubmission"
+	"github.com/Regncon/conorganizer/components/icons"
 	"github.com/Regncon/conorganizer/layouts"
 	"github.com/Regncon/conorganizer/models"
+	"github.com/Regncon/conorganizer/service/eventimage"
 	"github.com/Regncon/conorganizer/service/live"
 	"github.com/Regncon/conorganizer/service/puljefordeling"
 	"github.com/Regncon/conorganizer/service/userctx"
@@ -24,7 +27,7 @@ import (
 // mirrors the bordfordeling (rooms assignment) layout: a tab strip per pulje and
 // a connected panel that live-updates over SSE. It is a read-only what-if view of
 // the emulated distribution — nothing is written to assignment tables here.
-func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manager, logger *slog.Logger) {
+func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manager, logger *slog.Logger, eventImageDir *string) {
 	logger = logger.With("component", "admin_puljefordeling_tab")
 
 	router.Route("/puljefordeling", func(puljefordelingRouter chi.Router) {
@@ -46,7 +49,7 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 			if err := layouts.Base(
 				"Puljefordeling",
 				userInfo,
-				puljefordelingIndex(db, logger, puljeID),
+				puljefordelingIndex(db, logger, puljeID, eventImageDir),
 			).Render(r.Context(), w); err != nil {
 				logger.Error(fmt.Errorf("failed to render puljefordeling page: %w", err).Error(), "user_id", userInfo.Id)
 			}
@@ -67,7 +70,7 @@ func puljefordelingRoute(router chi.Router, db *sql.DB, liveManager *live.Manage
 		liveManager.Stream(w, r, live.Page{
 			Buckets: []live.Bucket{live.BucketEvents, live.BucketInterests},
 			Render: func(ctx context.Context, r *http.Request) templ.Component {
-				return PuljefordelingTabContent(db, logger, puljeID)
+				return PuljefordelingTabContent(db, logger, puljeID, eventImageDir)
 			},
 		})
 	})
@@ -224,7 +227,7 @@ func unsatisfiedAfter(em puljefordeling.Emulation, pulje models.Pulje) (int, boo
 	return 0, false
 }
 
-templ puljefordelingIndex(db *sql.DB, logger *slog.Logger, current models.Pulje) {
+templ puljefordelingIndex(db *sql.DB, logger *slog.Logger, current models.Pulje, eventImageDir *string) {
 	@components.Breadcrumbs([]components.BreadcrumbPath{
 		{Name: "Hjem", Url: "/"},
 		{Name: "Admin", Url: "/admin/"},
@@ -289,12 +292,12 @@ templ puljefordelingIndex(db *sql.DB, logger *slog.Logger, current models.Pulje)
 				>{ pulje }</a>
 			}
 		</div>
-		@PuljefordelingTabContent(db, logger, current)
+		@PuljefordelingTabContent(db, logger, current, eventImageDir)
 		@puljeAssignDialog(db, logger, current)
 	</div>
 }
 
-templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje) {
+templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pulje, eventImageDir *string) {
 	{{
 		puljer, puljerErr := getPuljer(db)
 		if puljerErr != nil {
@@ -374,6 +377,8 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             gap: var(--responsive-page-section-spacing);
         }
         .pulje-event {
+            position: relative;
+            overflow: hidden;
             display: flex;
             flex-flow: column nowrap;
             gap: var(--spacing-1x);
@@ -383,12 +388,52 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             background-color: var(--bg-item);
             transition: border-color 300ms ease-in-out;
         }
+        /* Faded banner art behind each game, mirroring the rooms cards. */
+        .pulje-event-bg {
+            position: absolute;
+            inset: 0;
+            z-index: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        /* Full-box gradient so the tags and player list stay legible over the
+           image — these boxes carry far more text than the small room cards. */
+        .pulje-event::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            z-index: 1;
+            background: linear-gradient(
+                to bottom,
+                rgba(53, 57, 74, 0.82) 0%,
+                rgba(53, 57, 74, 0.9) 45%,
+                rgba(53, 57, 74, 0.97) 100%
+            );
+        }
+        .pulje-event > *:not(.pulje-event-bg) {
+            position: relative;
+            z-index: 2;
+        }
         .pulje-event:hover {
             border-color: var(--bg-item-border-hover);
         }
         .pulje-event.is-drag-over {
             border-color: var(--color-primary);
             background-color: var(--bg-surface);
+        }
+        /* Event property tags (game type, age, runtime, beginner/english). */
+        .pulje-tags {
+            display: flex;
+            flex-flow: row wrap;
+            gap: var(--spacing-1x) var(--spacing-3x);
+            color: var(--color-text-soft);
+            font-size: var(--text-small, 0.85rem);
+        }
+        .pulje-tags > div {
+            background-color: rgba(20, 22, 30, 0.45);
+            padding: 0 var(--spacing-2x);
+            border-radius: var(--border-radius-1x);
         }
         .pulje-players li[draggable="true"] {
             cursor: grab;
@@ -444,6 +489,8 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
             padding: var(--spacing-1x);
             border: 1px solid var(--bg-item-border);
             border-radius: var(--border-radius-1x);
+            background-color: rgba(20, 22, 30, 0.4);
+            backdrop-filter: blur(2px);
         }
         .pulje-players li.moved {
             border-left: 3px solid var(--color-accent-red);
@@ -545,7 +592,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 			</div>
 		</div>
 		<div class="pulje-legend">
-			<p>🔥 Veldig interessert · 👍 Middels · 🤷 Litt · 📌 Ikke interessert, manuelt plassert</p>
+			<p>🤩 Veldig interessert · 🙂 Middels · 🤨 Litt · 📌 Ikke interessert, manuelt plassert</p>
 			<p><span class="legend-dm-name">Turkis navn</span> = Spilleder</p>
 			<p>
 				<span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
@@ -558,7 +605,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 		} else {
 			<div class="pulje-event-grid">
 				for _, ev := range result.Events {
-					@puljeEventBox(pulje, ev, puljeIsCompleted(row.Status))
+					@puljeEventBox(pulje, ev, puljeIsCompleted(row.Status), eventImageDir)
 				}
 			</div>
 			if len(result.Unassigned) > 0 {
@@ -623,7 +670,7 @@ templ puljeStatusToggles(pulje models.PuljeRow) {
 	</div>
 }
 
-templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, published bool) {
+templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, published bool, eventImageDir *string) {
 	{{
 		// A non-published event box is a drop target: dropping a dragged player
 		// pins them here via the assign endpoint (mirrors the rooms drag-and-drop).
@@ -633,12 +680,15 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, publish
 			dropAttrs["data-on:drop__prevent"] = fmt.Sprintf("$dragOverEvent = ''; $draggedBillettholderId && (($assignmentBillettholderId = $draggedBillettholderId), ($assignmentEventId = '%s'), ($assignmentPuljeId = '%s'), @post('/admin/api/puljefordeling/assign'))", ev.EventID, string(pulje))
 			dropAttrs["data-class:is-drag-over"] = fmt.Sprintf("$dragOverEvent === '%s'", ev.EventID)
 		}
+		imageBannerUrl := eventimage.GetEventImageUrl(ev.EventID, "banner", eventImageDir)
 	}}
 	<div class={ "pulje-event", templ.KV("missing-dm", ev.GMName == "") } { dropAttrs... }>
+		<img class="pulje-event-bg" src={ imageBannerUrl } alt="" aria-hidden="true"/>
 		<div class="pulje-event-top">
 			<h3>{ ev.Title }</h3>
 			<span class="pulje-cap">{ fmt.Sprintf("%d / %d", len(ev.AssignedPlayers), ev.Capacity) }</span>
 		</div>
+		@puljeEventTags(ev)
 		if ev.GMName != "" {
 			<p class="pulje-gm">Spilleder: { ev.GMName }</p>
 		} else {
@@ -688,6 +738,42 @@ templ puljeEventBox(pulje models.Pulje, ev puljefordeling.EmulatedEvent, publish
 				class="pulje-add"
 				data-on:click={ fmt.Sprintf("$assignmentEventId = '%s'; $assignmentPuljeId = '%s'; document.getElementById('puljefordeling-assign-dialog').showModal()", ev.EventID, string(pulje)) }
 			>+ Legg til deltaker</button>
+		}
+	</div>
+}
+
+// puljeEventTags renders the event's property badges (game type, age group,
+// runtime, beginner/English) using the same SVG icons as the event detail page,
+// so an admin can read a game's nature at a glance without leaving the view.
+templ puljeEventTags(ev puljefordeling.EmulatedEvent) {
+	<div class="pulje-tags">
+		switch ev.EventType {
+			case models.EventTypeRoleplay:
+				@event_components.Event_property(ev.EventType.Label(), icons.EventRoleplay)
+			case models.EventTypeBoardGame:
+				@event_components.Event_property(ev.EventType.Label(), icons.EventBoardgame)
+			case models.EventTypeCardGame:
+				@event_components.Event_property(ev.EventType.Label(), icons.EventCardgame)
+			case models.EventTypeOther:
+				@event_components.Event_property(ev.EventType.Label(), icons.EventOtherGames)
+		}
+		if ev.AgeGroup == models.AgeGroupAdultsOnly {
+			@event_components.Event_property(ev.AgeGroup.BadgeLabel(), icons.EventAdultOnly)
+		}
+		if ev.AgeGroup == models.AgeGroupChildFriendly {
+			@event_components.Event_property(ev.AgeGroup.BadgeLabel(), icons.EventChildFriendly)
+		}
+		if ev.Runtime == models.RunTimeLongRunning {
+			@event_components.Event_property(ev.Runtime.BadgeLabel(), icons.TimeOver6Hours)
+		}
+		if ev.Runtime == models.RunTimeShortRunning {
+			@event_components.Event_property(ev.Runtime.BadgeLabel(), icons.TimeUnder3Hours)
+		}
+		if ev.BeginnerFriendly {
+			@event_components.Event_property("Nybegynnervennlig", icons.EventBeginnerFriendly)
+		}
+		if ev.CanBeRunInEnglish {
+			@event_components.Event_property("Can be run in English", icons.EventEnglish)
 		}
 	</div>
 }

--- a/pages/admin/puljefordeling_tab.templ
+++ b/pages/admin/puljefordeling_tab.templ
@@ -595,7 +595,7 @@ templ PuljefordelingTabContent(db *sql.DB, logger *slog.Logger, pulje models.Pul
 			<p>🤩 Veldig interessert · 🙂 Middels · 🤨 Litt · 📌 Ikke interessert, manuelt plassert</p>
 			<p><span class="legend-dm-name">Turkis navn</span> = Spilleder</p>
 			<p>
-				<span class="legend-strek legend-moved">Rød strek</span> = flyttet for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
+				<span class="legend-strek legend-moved">Rød strek</span> = flyttet NED for å gi plass · <span class="legend-strek legend-manual">Gul strek</span> = manuell
 			</p>
 		</div>
 		if emErr != nil {

--- a/pages/admin/puljefordeling_tab_assignment_test.go
+++ b/pages/admin/puljefordeling_tab_assignment_test.go
@@ -20,7 +20,7 @@ import (
 func TestPuljefordelingRemoveManualSeatRoute_DeletesPin(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
@@ -65,7 +65,7 @@ func TestPuljefordelingTabContent_RendersAddPickerAndManualRemove(t *testing.T) 
 	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
 		VALUES ('evA',?,1,'Player','manual')`, string(fredag))
 
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, fredag))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, fredag, nil))
 	html, err := doc.Html()
 	if err != nil {
 		t.Fatalf("render html: %v", err)
@@ -92,7 +92,7 @@ func TestPuljefordelingIndex_DialogRendersOutsideLiveRegion(t *testing.T) {
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
 
-	doc := templtest.Render(t, puljefordelingIndex(db, logger, fredag))
+	doc := templtest.Render(t, puljefordelingIndex(db, logger, fredag, nil))
 
 	if got := doc.Find("#puljefordeling-assign-dialog").Length(); got != 1 {
 		t.Fatalf("expected exactly one assign dialog, got %d", got)
@@ -160,7 +160,7 @@ func postAssignSignals(t *testing.T, router http.Handler, bhID int, eventID, pul
 func TestPuljefordelingCommitRoute_PersistsSolverPicks(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_commit_route")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
@@ -194,7 +194,7 @@ func TestPuljefordelingCommitRoute_PersistsSolverPicks(t *testing.T) {
 func TestPuljefordelingAssignRoute_PinsWithoutCreatingInterest(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_assign_route")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
@@ -227,7 +227,7 @@ func TestPuljefordelingAssignRoute_PinsWithoutCreatingInterest(t *testing.T) {
 func TestPuljefordelingAssignRoute_RejectsWhenPublished(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_assign_published")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusCompleted, "2026-01-01 18:00")
@@ -253,7 +253,7 @@ func TestPuljefordelingAssignRoute_RejectsWhenPublished(t *testing.T) {
 func TestPuljefordelingRemoveManualSeatRoute_RejectsWhenPublished(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_published")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	const fredag = models.PuljeFredagKveld
 	seedTabPulje(t, db, fredag, "Fredag Kveld", models.PuljeStatusCompleted, "2026-01-01 18:00")
@@ -286,7 +286,7 @@ func TestPuljefordelingRemoveManualSeatRoute_RejectsWhenPublished(t *testing.T) 
 func TestPuljefordelingRemoveManualSeatRoute_RejectsInvalidPulje(t *testing.T) {
 	db, logger := testutil.CreateTestDBAndLogger(t, "puljefordeling_remove_route_invalid")
 	router := chi.NewRouter()
-	puljefordelingRoute(router, db, &live.Manager{}, logger)
+	puljefordelingRoute(router, db, &live.Manager{}, logger, nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/puljefordeling/NotAPulje/evA/1", nil)
 	rec := httptest.NewRecorder()

--- a/pages/admin/puljefordeling_tab_test.go
+++ b/pages/admin/puljefordeling_tab_test.go
@@ -71,7 +71,7 @@ func TestPuljefordelingTabContent_RendersPuljeEventsAndStatusToggles(t *testing.
 	seedTabEventWithInterest(t, db, "drager-og-fangehull", "Drager og Fangehull", models.PuljeFredagKveld)
 
 	// When
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 	actualText := strings.Join(templtest.CollectTexts(doc, "#puljefordeling-tab"), " ")
 
 	// Then
@@ -97,7 +97,7 @@ func TestPuljefordelingTabContent_ShowsRunningUnsatisfiedCount(t *testing.T) {
 
 	// When / Then: earlier pulje — participant not yet satisfied.
 	fredag := strings.Join(
-		templtest.CollectTexts(templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld)), "#puljefordeling-tab"),
+		templtest.CollectTexts(templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil)), "#puljefordeling-tab"),
 		" ",
 	)
 	if !strings.Contains(fredag, "1 uten førstevalg så langt") {
@@ -106,7 +106,7 @@ func TestPuljefordelingTabContent_ShowsRunningUnsatisfiedCount(t *testing.T) {
 
 	// When / Then: later pulje — participant gets their first choice.
 	lordag := strings.Join(
-		templtest.CollectTexts(templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeLordagKveld)), "#puljefordeling-tab"),
+		templtest.CollectTexts(templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeLordagKveld, nil)), "#puljefordeling-tab"),
 		" ",
 	)
 	if !strings.Contains(lordag, "0 uten førstevalg så langt") {
@@ -129,7 +129,7 @@ func TestPuljefordelingTabContent_WarnsWhenEventHasNoDm(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO relation_event_puljer (event_id, pulje_id, is_in_pulje) VALUES ('evA',?,1)`, string(models.PuljeFredagKveld))
 
 	// When
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 	text := strings.Join(templtest.CollectTexts(doc, "#puljefordeling-tab"), " ")
 
 	// Then
@@ -155,7 +155,7 @@ func TestPuljefordelingTabContent_PublishedHidesAssignmentControls(t *testing.T)
 	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
 		VALUES ('evA',?,1,'Player','manual')`, string(models.PuljeFredagKveld))
 
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 
 	if n := doc.Find(".pulje-add").Length(); n != 0 {
 		t.Errorf("published pulje must not show the add button, found %d", n)
@@ -176,7 +176,7 @@ func TestPuljefordelingTabContent_PlayerTilesDragToEventBoxes(t *testing.T) {
 	seedTabPulje(t, db, models.PuljeFredagKveld, "Fredag Kveld", models.PuljeStatusOpen, "2026-01-01 18:00")
 	seedTabEventWithInterest(t, db, "evA", "Alpha", models.PuljeFredagKveld)
 
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 
 	tile := doc.Find(".pulje-players li[draggable='true']")
 	if tile.Length() == 0 {
@@ -197,7 +197,7 @@ func TestPuljefordelingTabContent_PublishedTilesNotDraggable(t *testing.T) {
 	seedTabPulje(t, db, models.PuljeFredagKveld, "Fredag Kveld", models.PuljeStatusCompleted, "2026-01-01 18:00")
 	seedTabEventWithInterest(t, db, "evA", "Alpha", models.PuljeFredagKveld)
 
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 
 	if n := doc.Find(".pulje-players li[draggable='true']").Length(); n != 0 {
 		t.Errorf("published pulje must not allow dragging, found %d draggable tiles", n)
@@ -222,7 +222,7 @@ func TestPuljefordelingTabContent_PinEmojiForManualWithoutInterest(t *testing.T)
 	testutil.MustExec(t, db, `INSERT INTO relation_events_players (event_id, pulje_id, billettholder_id, role, source)
 		VALUES ('evA',?,1,'Player','manual')`, string(models.PuljeFredagKveld))
 
-	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld))
+	doc := templtest.Render(t, PuljefordelingTabContent(db, logger, models.PuljeFredagKveld, nil))
 	text := strings.Join(templtest.CollectTexts(doc, "#puljefordeling-tab"), " ")
 
 	if !strings.Contains(text, "📌") {

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -22,7 +22,7 @@ type AssignedPlayer struct {
 	Name            string
 	IsDM            bool                 // runs at least one game in the weekend (DM bump)
 	Level           models.InterestLevel // their interest in the game they got
-	Moved           bool                 // relocated off a higher-scoring event by the solver to make room for others
+	Moved           bool                 // bumped down to a strictly lower-interest event by the solver to make room (equal-interest swaps don't count)
 	Manual          bool                 // manually pinned into this event by an admin (source='manual'), not placed by the solver
 }
 

--- a/service/puljefordeling/emulate.go
+++ b/service/puljefordeling/emulate.go
@@ -33,14 +33,21 @@ const (
 	SourceSolver = "solver"
 )
 
-// EmulatedEvent is the proposed seating for a single event within a pulje.
+// EmulatedEvent is the proposed seating for a single event within a pulje. The
+// metadata fields (type/age/runtime/flags) drive the tag row in the UI and carry
+// no weight in the distribution itself.
 type EmulatedEvent struct {
-	EventID         string
-	Title           string
-	Capacity        int
-	GMName          string           // empty if the event has no GM assigned
-	AssignedPlayers []AssignedPlayer // sorted by name
-	Undersubscribed bool             // fewer than the solver's viable-player threshold
+	EventID           string
+	Title             string
+	Capacity          int
+	GMName            string           // empty if the event has no GM assigned
+	AssignedPlayers   []AssignedPlayer // sorted by name
+	Undersubscribed   bool             // fewer than the solver's viable-player threshold
+	EventType         models.EventType
+	AgeGroup          models.AgeGroup
+	Runtime           models.Runtime
+	BeginnerFriendly  bool
+	CanBeRunInEnglish bool
 }
 
 // EmulatedPulje is the proposed seating for one pulje (time slot).
@@ -62,8 +69,13 @@ type Emulation struct {
 }
 
 type eligibleEvent struct {
-	title    string
-	capacity int
+	title             string
+	capacity          int
+	eventType         models.EventType
+	ageGroup          models.AgeGroup
+	runtime           models.Runtime
+	beginnerFriendly  bool
+	canBeRunInEnglish bool
 }
 
 // EmulateSeatings builds the solver model from the database, runs the
@@ -137,7 +149,7 @@ func EmulateSeatings(db *sql.DB) (Emulation, error) {
 	for i, slot := range weekend.Slots {
 		pulje := puljer[i]
 		res := state.SolveSlotFixed(slot, players, pins[pulje.ID])
-		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet, pins[pulje.ID]))
+		emulation.Puljer = append(emulation.Puljer, shapePulje(pulje, slot, res, gms, names, prefs, dmSet, pins[pulje.ID], events[pulje.ID]))
 	}
 	emulation.SatisfiedTotal = state.SatisfiedCount()
 
@@ -154,6 +166,7 @@ func shapePulje(
 	prefs map[int]map[string]map[string]smodel.Score,
 	dmSet map[int]bool,
 	manual map[string]string,
+	meta map[string]eligibleEvent,
 ) EmulatedPulje {
 	under := make(map[string]bool, len(res.UndersubscribedEvents))
 	for _, eid := range res.UndersubscribedEvents {
@@ -180,6 +193,13 @@ func shapePulje(
 			Capacity:        ev.Capacity,
 			AssignedPlayers: assignedPlayers(res.Assignments[ev.ID], ev.ID, string(pulje.ID), names, prefs, dmSet, moved, manual),
 			Undersubscribed: under[ev.ID],
+		}
+		if m, ok := meta[ev.ID]; ok {
+			emEv.EventType = m.eventType
+			emEv.AgeGroup = m.ageGroup
+			emEv.Runtime = m.runtime
+			emEv.BeginnerFriendly = m.beginnerFriendly
+			emEv.CanBeRunInEnglish = m.canBeRunInEnglish
 		}
 		if gmID, ok := gms[eventPuljeKey(ev.ID, pulje.ID)]; ok {
 			emEv.GMName = names[gmID]
@@ -250,7 +270,9 @@ func loadPuljer(db *sql.DB) ([]models.PuljeRow, error) {
 
 func loadEligibleEvents(db *sql.DB) (map[models.Pulje]map[string]eligibleEvent, error) {
 	const query = `
-		SELECT ep.pulje_id, e.id, e.title, e.max_players
+		SELECT ep.pulje_id, e.id, e.title, e.max_players,
+		       e.event_type, e.age_group, e.event_runtime,
+		       e.beginner_friendly, e.can_be_run_in_english
 		FROM relation_event_puljer ep
 		JOIN events e ON e.id = ep.event_id
 		WHERE ep.is_in_pulje = 1
@@ -266,13 +288,20 @@ func loadEligibleEvents(db *sql.DB) (map[models.Pulje]map[string]eligibleEvent, 
 		var pulje models.Pulje
 		var eventID, title string
 		var maxPlayers int
-		if err := rows.Scan(&pulje, &eventID, &title, &maxPlayers); err != nil {
+		var ev eligibleEvent
+		if err := rows.Scan(
+			&pulje, &eventID, &title, &maxPlayers,
+			&ev.eventType, &ev.ageGroup, &ev.runtime,
+			&ev.beginnerFriendly, &ev.canBeRunInEnglish,
+		); err != nil {
 			return nil, fmt.Errorf("scan event row: %w", err)
 		}
+		ev.title = title
+		ev.capacity = maxPlayers
 		if out[pulje] == nil {
 			out[pulje] = make(map[string]eligibleEvent)
 		}
-		out[pulje][eventID] = eligibleEvent{title: title, capacity: maxPlayers}
+		out[pulje][eventID] = ev
 	}
 	return out, rows.Err()
 }

--- a/service/puljefordeling/emulate_test.go
+++ b/service/puljefordeling/emulate_test.go
@@ -155,7 +155,7 @@ func TestEmulateSeatings(t *testing.T) {
 	if slices.Contains(playerNames(evA.AssignedPlayers), "Game Master") {
 		t.Errorf("GM should not be seated as a player, got %v", playerNames(evA.AssignedPlayers))
 	}
-	// Everyone seated in evA wanted it highly → 🔥 level surfaced.
+	// Everyone seated in evA wanted it highly → 🤩 level surfaced.
 	for _, ap := range evA.AssignedPlayers {
 		if ap.Level != models.InterestLevelHigh {
 			t.Errorf("evA seat %q: want level High, got %q", ap.Name, ap.Level)

--- a/service/puljefordeling/solver/model/model.go
+++ b/service/puljefordeling/solver/model/model.go
@@ -48,7 +48,7 @@ type SlotResult struct {
 	UndersubscribedEvents []string            // eventIDs assigned fewer players than MinPlayers — flagged for organiser review (not cancelled)
 	Unassigned            []string            // playerIDs with interest but no seat
 	NewlySatisfied        []string            // playerIDs satisfied for the first time this slot
-	MovedPlayers          []string            // playerIDs relocated off a higher-scoring event by a residual-edge augmentation
+	MovedPlayers          []string            // playerIDs bumped down to a strictly lower-interest event to make room (lateral, equal-interest swaps are excluded)
 	TotalScore            int                 // sum of actual (unadjusted) scores for all assignments
 	Seed                  int64               // seed used for tie-breaking shuffle this slot
 }

--- a/service/puljefordeling/solver/solver.go
+++ b/service/puljefordeling/solver/solver.go
@@ -244,7 +244,7 @@ func (s *State) SolveSlotFixed(slot model.Slot, players []model.Player, fixed ma
 	// Update fairness/totals/misses/unassigned; returns the seated set.
 	assigned := s.applyResult(&result, slot.ID, interested, playerByID, assignments)
 
-	// Players bumped off a higher-scoring event by a residual augmentation and
+	// Players bumped down to a strictly lower-interest event (see runMCMF) and
 	// still holding a seat.
 	for pid := range moved {
 		if _, ok := assigned[pid]; ok {
@@ -386,17 +386,25 @@ func (s *State) runMCMF(
 
 	// A reduced forward edge ran player→event (forward at fe, its reverse at
 	// fe^1 runs event→player, so its .to is the player node). Flow pushed back
-	// along it means that player was bumped off the event.
-	moved := make(map[string]struct{})
+	// along it means that player was bumped off the event. Record the player's
+	// (true, unadjusted) score for the seat they lost — the best one if a chain
+	// of augmentations bumped them off more than one — so we can later tell a
+	// downgrade apart from a lateral move between equally-wanted seats.
+	movedFromScore := make(map[string]model.Score)
 	for _, fe := range reduced {
 		playerNode := g.edges[fe^1].to
 		eventNode := g.edges[fe].to
 		if playerNode < 1 || playerNode > P || eventNode < P+1 || eventNode > P+E {
 			continue
 		}
-		moved[players[playerNode-1].ID] = struct{}{}
+		p := players[playerNode-1]
+		fromScore := p.Prefs[slotID][events[eventNode-P-1].ID]
+		if fromScore > movedFromScore[p.ID] {
+			movedFromScore[p.ID] = fromScore
+		}
 	}
 
+	finalScore := make(map[string]model.Score, len(players))
 	for i, p := range players {
 		for _, eid := range g.adj[i+1] {
 			e := g.edges[eid]
@@ -405,6 +413,18 @@ func (s *State) runMCMF(
 			}
 			evID := events[e.to-P-1].ID
 			assignments[evID] = append(assignments[evID], p.ID)
+			finalScore[p.ID] = p.Prefs[slotID][evID]
+		}
+	}
+
+	// "Moved" is reserved for a genuine downgrade: the player ended up on a
+	// strictly lower-interest seat than the one they were bumped off. A swap
+	// between two equally-wanted events (e.g. High → High) is a lateral move and
+	// is not flagged.
+	moved := make(map[string]struct{})
+	for pid, fromScore := range movedFromScore {
+		if toScore, ok := finalScore[pid]; ok && fromScore > toScore {
+			moved[pid] = struct{}{}
 		}
 	}
 

--- a/service/puljefordeling/solver/solver_test.go
+++ b/service/puljefordeling/solver/solver_test.go
@@ -458,6 +458,32 @@ func TestSolveSlot_ReverseEdgeBumpMarksMoved(t *testing.T) {
 	}
 }
 
+func TestSolveSlot_LateralBumpAtEqualLevelNotMoved(t *testing.T) {
+	// Same bump mechanics as above, but "a" wants X and Y equally (both top
+	// choice, score 5). The solver still bumps "a" off X to seat "b", but "a"
+	// lands on an equally-wanted seat — High → High is a lateral move, not a
+	// downgrade, so "a" must NOT be flagged moved (the red "flyttet ned" stripe
+	// is reserved for players pushed to a strictly lower-interest seat).
+	sl1 := slot("s1", event("X", 1), event("Y", 1))
+	sl2 := slot("s2", model.Event{ID: "Z", Name: "Z", Capacity: 4, DMID: "a"})
+
+	a := model.Player{ID: "a", Name: "a", Prefs: map[string]map[string]model.Score{"s1": {"X": 5, "Y": 5}}}
+	b := model.Player{ID: "b", Name: "b", Prefs: map[string]map[string]model.Score{"s1": {"X": 5}}}
+
+	st := NewState(2026, weekendOf(sl1, sl2))
+	result := st.SolveSlot(sl1, []model.Player{a, b})
+
+	if !slices.Contains(assigned(result, "X"), "b") {
+		t.Errorf("b should win the X seat, got %v", assigned(result, "X"))
+	}
+	if !slices.Contains(assigned(result, "Y"), "a") {
+		t.Errorf("a should land on its equally-wanted Y seat, got %v", assigned(result, "Y"))
+	}
+	if slices.Contains(result.MovedPlayers, "a") {
+		t.Errorf("a was moved between two equally-wanted seats (High→High) and must NOT be flagged moved, got %v", result.MovedPlayers)
+	}
+}
+
 func TestSolveSlot_NoBumpLeavesMovedEmpty(t *testing.T) {
 	// Two players, two disjoint top choices: each is seated directly, no reverse
 	// edge is ever used, so nobody is marked moved.


### PR DESCRIPTION
## What

Visual polish pass on the per-pulje puljefordeling admin view, which was built quickly with plain emojis and no event context. Presentation-only — no solver, distribution, or DB-write behaviour changes.

### 1. Consistent interest icons (single source of truth)
- `InterestLevel.Emoji()` now returns the interest picker's glyphs — `🤩` / `🙂` / `🤨` (were `🔥`/`👍`/`🤷`). `None` stays `""` so the manual-pin `📌` logic is untouched.
- Refactored the interest picker's three active buttons to call `.Emoji()` so the picker and puljefordeling share one source and can't drift again.
- Updated the puljefordeling legend to match.

### 2. Event tags on each game box
- Enriched `EmulatedEvent` with `EventType / AgeGroup / Runtime / BeginnerFriendly / CanBeRunInEnglish`, fed by an extended `loadEligibleEvents` query.
- New `puljeEventTags` renders them via the existing `Event_property` component — the same SVG icons as the event detail page (game type always; age/runtime/beginner/English conditionally).

### 3. Faded background image + transparent player boxes
- Threaded `eventImageDir` from `SetupAdminRoute` into `puljeEventBox`.
- Each box gets a banner `<img>` background + a full-box dark gradient overlay (heavier than the rooms' left-to-right one, since these boxes carry more text), with content layered above. Player rows get a semi-transparent blurred background so the art shows through while staying legible.

## Testing
- `go build ./...`, `go vet`, and `go test ./...` all pass.
- Updated affected test call sites for the new `eventImageDir` parameter.


<!-- preview-deployment-url:start -->
## Preview deployment

_Added automatically by CI_

🔗 https://473-merge.lekeplassen.regncon.no
<!-- preview-deployment-url:end -->